### PR TITLE
fix: use actual Cargo.toml version for LSP server info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "solidity-language-server"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solidity-language-server"
 description = "A solidity language server with foundry's build process."
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -182,8 +182,8 @@ impl LanguageServer for ForgeLsp {
     ) -> tower_lsp::jsonrpc::Result<InitializeResult> {
         Ok(InitializeResult {
             server_info: Some(ServerInfo {
-                name: "forge lsp".to_string(),
-                version: Some("0.0.1".to_string()),
+                name: "Solidity Language Server".to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
             }),
             capabilities: ServerCapabilities {
                 completion_provider: Some(CompletionOptions {


### PR DESCRIPTION
## Summary

- Replace hardcoded server name (`"forge lsp"`) and version (`"0.0.1"`) with `"Solidity Language Server"` and `env!("CARGO_PKG_VERSION")` so the LSP server info automatically stays in sync with `Cargo.toml`
- Bump version from `0.1.8` to `0.1.9`
- Include updated `Cargo.lock`

Closes #15