### PR TITLE
fix: read commit hash from .cargo_vcs_info.json for crates.io builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,10 @@
 use std::process::Command;
 
 fn main() {
-    // Git commit hash
-    let commit = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
+    // Git commit hash: try git first, fall back to .cargo_vcs_info.json
+    // (which cargo embeds automatically when publishing to crates.io)
+    let commit = git_commit()
+        .or_else(cargo_vcs_commit)
         .unwrap_or_else(|| "unknown".to_string());
 
     let version = env!("CARGO_PKG_VERSION");
@@ -20,4 +17,37 @@ fn main() {
     // Rerun if git HEAD changes
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/");
+    println!("cargo:rerun-if-changed=.cargo_vcs_info.json");
+}
+
+/// Read commit hash from local git repo.
+fn git_commit() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+/// Read commit hash from .cargo_vcs_info.json (present in crates.io builds).
+fn cargo_vcs_commit() -> Option<String> {
+    let content = std::fs::read_to_string(".cargo_vcs_info.json").ok()?;
+    // Parse: {"git":{"sha1":"abc123..."}}
+    // Avoid pulling in serde for the build script — just find the sha1 value.
+    let sha1_key = "\"sha1\"";
+    let idx = content.find(sha1_key)?;
+    let rest = &content[idx + sha1_key.len()..];
+    let start = rest.find('"')? + 1;
+    let end = start + rest[start..].find('"')?;
+    let full_sha = &rest[start..end];
+    // Return short hash (first 7 chars) to match git --short
+    Some(full_sha.chars().take(7).collect())
 }


### PR DESCRIPTION
## Summary

Closes #28

- `--version` showed `commit..macos.aarch64` (empty hash) when installed via `cargo install` because crates.io tarballs have no `.git` directory
- Falls back to `.cargo_vcs_info.json` which cargo embeds automatically at publish time
- Parses the short hash (first 7 chars) from the full SHA without pulling in serde for the build script

## Before

```
solidity-language-server 0.1.12+commit..macos.aarch64
```

## After

```
solidity-language-server 0.1.13+commit.c37f736.macos.aarch64
```