### PR TITLE
Fix: clear caches on did_close to free memory

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -461,9 +461,13 @@ impl LanguageServer for ForgeLsp {
         }
     }
 
-    async fn did_close(&self, _: DidCloseTextDocumentParams) {
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let uri = params.text_document.uri.to_string();
+        self.ast_cache.write().await.remove(&uri);
+        self.text_cache.write().await.remove(&uri);
+        self.completion_cache.write().await.remove(&uri);
         self.client
-            .log_message(MessageType::INFO, "file closed.")
+            .log_message(MessageType::INFO, "file closed, caches cleared.")
             .await;
     }
 


### PR DESCRIPTION
Clear AST, text, and completion caches when a file is closed via `textDocument/didClose`. Previously these were never evicted, leaking memory for every file opened during a session.

Closes #35