### PR TITLE
feat: announce LONG_VERSION in LSP ServerInfo

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -243,7 +243,7 @@ impl LanguageServer for ForgeLsp {
         Ok(InitializeResult {
             server_info: Some(ServerInfo {
                 name: "Solidity Language Server".to_string(),
-                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                version: Some(env!("LONG_VERSION").to_string()),
             }),
             capabilities: ServerCapabilities {
                 position_encoding: Some(encoding.to_encoding_kind()),


### PR DESCRIPTION
## Summary

- Use `LONG_VERSION` (`version+commit.<hash>.<os>.<arch>`) instead of `CARGO_PKG_VERSION` in the LSP `initialize` response `ServerInfo.version` field, so clients know the exact commit the server was built from.
- Aligns the LSP server version announcement with the CLI `--version` output, which already uses `LONG_VERSION`.

### Before

```
ServerInfo { name: "Solidity Language Server", version: "0.1.14" }
```

### After

```
ServerInfo { name: "Solidity Language Server", version: "0.1.14+commit.d798cbe.macos.aarch64" }
```

No changes to the build script — `LONG_VERSION` was already constructed in `build.rs` with the commit hash, OS, and architecture. This is a one-line change to wire it up in the LSP handshake.