### PR TITLE
deprecate --completion-mode flag

### DIFF
--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -1763,7 +1763,7 @@ fn test_scope_chain_completions_with_context() {
 #[test]
 fn test_scope_chain_completions_without_context_uses_flat() {
     let cache = load_cache();
-    // Without scope context (fast mode), self. resolves via flat first-wins lookup
+    // Without scope context (no file_id), self. resolves via flat first-wins lookup
     let chain = vec![DotSegment {
         name: "self".to_string(),
         kind: AccessKind::Plain,


### PR DESCRIPTION
Closes #58

Scope-aware completions are now always enabled. The `--completion-mode` flag is kept as a hidden no-op that logs a deprecation warning if used. The `fast` code path and `fast_completions` field are removed — all dot-completions use scope-aware resolution.

182 tests passing.