### PR TITLE
fix(build): simplify diagnostic path matching to fix silent drop

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::OnceLock,
-};
+use std::sync::OnceLock;
 use tower_lsp::lsp_types::PositionEncodingKind;
 
 /// How the LSP client counts column offsets within a line.
@@ -171,31 +168,4 @@ pub fn is_valid_solidity_identifier(name: &str) -> bool {
         }
     }
     true
-}
-
-/// Returns the path of the top-level directory of the working git tree.
-pub fn find_git_root(path: impl AsRef<Path>) -> Option<PathBuf> {
-    path.as_ref()
-        .ancestors()
-        .find(|p| p.join(".git").exists())
-        .map(Path::to_path_buf)
-}
-
-/// Finds the foundry project root by walking up from `path` looking for `foundry.toml`,
-/// bounded by the git root. Falls back to the git root if no `foundry.toml` is found.
-pub fn find_project_root(path: impl AsRef<Path>) -> Option<PathBuf> {
-    let path = path.as_ref();
-    let boundary = find_git_root(path);
-    let found = path
-        .ancestors()
-        .take_while(|p| {
-            if let Some(boundary) = &boundary {
-                p.starts_with(boundary)
-            } else {
-                true
-            }
-        })
-        .find(|p| p.join("foundry.toml").is_file())
-        .map(Path::to_path_buf);
-    found.or(boundary)
 }


### PR DESCRIPTION
## Summary

- Fixes #62 — build diagnostics silently dropped when editor opens from repo root
- Regression from #55

## What changed

Replaced `find_project_root` + `strip_prefix` path matching with `path.ends_with(source_path)`.

Forge reports error paths relative to its working directory. The old approach tried to find the foundry project root and strip it from the absolute path, which fails when forge's CWD differs from the project root. The new approach simply checks if the absolute path ends with whatever relative path forge reported — works from any directory, with any project layout.

Removed `find_project_root` and `find_git_root` from `utils.rs` (no longer needed).

## Before (broken)
```
forge reports:       "example/Shop.sol"
project root:        /repo/example/
strip_prefix result: "Shop.sol"
comparison:          "Shop.sol" != "example/Shop.sol" → diagnostic dropped
```

## After (fixed)
```
forge reports:       "example/Shop.sol"
editor path:         /repo/example/Shop.sol
ends_with check:     /repo/example/Shop.sol ends with example/Shop.sol → match
```