### PR TITLE
feat: tree-sitter enhanced goto definition (#66)

### DIFF
--- a/notes/GOTO.md
+++ b/notes/GOTO.md
@@ -1,0 +1,142 @@
+# Solidity Language Server: Tree-sitter Enhanced Go-to-Definition
+
+## The Problem
+
+Go-to-definition depends on the Forge AST, which uses byte offsets (`src` fields like `"1234:56:2"`) to locate declarations. When the user edits a file and introduces errors:
+
+1. `forge build` fails → stale AST stays cached
+2. The stale AST's byte offsets no longer match the live buffer
+3. Byte offsets drift with every insertion/deletion above the cursor
+4. Go-to-definition either jumps to the wrong location or fails entirely
+
+This was reported in #2 by @Philogy — go-to-definition stops working while editing, which is exactly when you need it most. The initial fix (keeping stale AST cache on build failure) helped, but positions drifted as soon as the buffer diverged from the last successful build.
+
+## The Solution: Names Don't Drift
+
+**Key insight:** byte offsets shift when you edit code, but identifier names don't.
+
+The solution combines two data sources:
+
+- **Stale AST** (via `CompletionCache`) — knows the semantics: what each identifier refers to, inheritance chains, type information, cross-file resolution
+- **Tree-sitter on the live buffer** — knows the exact current positions of every identifier
+
+### Pipeline
+
+```
+cursor position
+    ↓
+tree-sitter: parse live buffer
+    ↓
+CursorContext { name: "totalSupply", function: "mint", contract: "Token" }
+    ↓
+CompletionCache: resolve name in scope chain
+    ↓
+ResolvedTarget::SameFile | ResolvedTarget::OtherFile { path, name }
+    ↓
+tree-sitter: find declaration by name in target file
+    ↓
+Location { uri, range }
+```
+
+### Step 1: CursorContext via tree-sitter ancestor walk
+
+Tree-sitter parses the live buffer and gives us the syntax tree. From the cursor position, we find the identifier node and walk **up** the tree to collect ancestor names:
+
+```
+identifier "totalSupply"
+  → expression_statement
+    → function_body
+      → function_definition (name: "mint")
+        → contract_body
+          → contract_declaration (name: "Token")
+```
+
+Result: `CursorContext { name: "totalSupply", function: Some("mint"), contract: Some("Token") }`
+
+No byte offsets involved. Just names from the parse tree.
+
+### Step 2: Scope resolution via CompletionCache
+
+The `CompletionCache` (built from the Forge AST at last successful build) already has everything we need:
+
+| Field | Purpose |
+|-------|---------|
+| `name_to_node_id` | Contract/library name → AST node ID |
+| `scope_declarations` | Scope node ID → declarations (name, type) |
+| `scope_parent` | Scope chain: child → parent |
+| `linearized_base_contracts` | C3 inheritance order per contract |
+
+Instead of `find_innermost_scope(byte_pos, file_id)` (which uses stale byte offsets), we use `find_scope_by_names(contract_name, function_name)`:
+
+1. Look up contract name in `name_to_node_id` → get contract scope ID
+2. Find function scope by walking `scope_parent` for scopes whose parent is the contract
+3. Check `scope_declarations` in function scope, then contract scope, then inherited contracts
+4. If the name is found in an inherited contract, resolve via `id_to_path_map` → cross-file jump
+
+### Step 3: Declaration location via tree-sitter
+
+Once we know the target (same file or other file), tree-sitter finds the declaration:
+
+`find_declarations_by_name(source, "totalSupply")` scans the parse tree for declaration nodes:
+
+- `state_variable_declaration` with identifier "totalSupply"
+- `function_definition` with identifier "totalSupply"
+- `parameter` nodes inside function/constructor parameter lists
+- `struct_declaration`, `enum_declaration`, `event_definition`, `error_declaration`
+- `enum_value` nodes for enum members
+- `variable_declaration` for local variables
+
+If multiple declarations match (e.g., same name in different contracts), we prefer the one in the same contract as the cursor.
+
+### Fallback
+
+If the tree-sitter path fails (no completion cache, unrecognized syntax), the existing AST-based goto runs as a fallback. This ensures no regression — the tree-sitter path only improves things.
+
+## The Formatting Race Condition
+
+A separate issue was discovered during testing: after saving with auto-format, `text_cache` became stale.
+
+### The sequence
+
+1. Save → `did_save` → `on_change` runs `forge build`, writes **pre-formatted** text to `text_cache`
+2. Formatter runs → returns edits to editor
+3. Editor applies edits → sends `did_change` → updates `text_cache` with formatted text
+4. But `on_change` (step 1) might still be running and **overwrites** `text_cache` with the old text
+
+### The fix
+
+Two changes:
+
+1. **Version guard in `on_change`**: only write to `text_cache` if our version is `>=` the existing version. This prevents a slow `on_change` from overwriting a newer `did_change` update.
+
+2. **Formatter updates `text_cache` immediately**: when the formatting handler produces new content, it writes to `text_cache` before returning the edits. This eliminates the stale window between formatting and the editor's `did_change` response.
+
+## What This Enables
+
+- **Go-to-definition works while editing** — no more waiting for successful builds
+- **Correct positions after formatting** — text_cache stays in sync with the editor buffer
+- **Semantic tokens stay accurate** — they also read from text_cache
+- **Same architecture as completions** — reuses `CompletionCache`, no new caching layer
+- **Parameter navigation** — go-to-definition works on function/constructor parameters
+
+## Reused Infrastructure
+
+| Component | From | Used For |
+|-----------|------|----------|
+| `CompletionCache` | completion.rs | Scope chain, type resolution, inheritance |
+| `scope_declarations` | completion.rs | Name → type mappings per scope |
+| `linearized_base_contracts` | completion.rs | C3 inheritance resolution |
+| `name_to_node_id` | completion.rs | Contract name → scope ID |
+| `text_cache` | lsp.rs | Live buffer content |
+| tree-sitter parser | symbols.rs | Parse live buffer for positions |
+
+## Test Coverage
+
+Unit tests in `goto.rs::ts_tests`:
+- `test_cursor_context_state_var` — identifier + ancestors inside a function
+- `test_cursor_context_top_level` — contract declaration name
+- `test_cursor_context_short_param` — parameter names (including short names like `tax`)
+- `test_find_declarations` — state variable lookup
+- `test_find_declarations_multiple_contracts` — disambiguation across contracts
+- `test_find_declarations_enum_value` — enum member lookup
+- `test_find_best_declaration_same_contract` — prefers same-contract match

--- a/src/goto.rs
+++ b/src/goto.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 use std::collections::HashMap;
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
+use tree_sitter::{Node, Parser};
 
 #[derive(Debug, Clone)]
 pub struct NodeInfo {
@@ -558,4 +559,690 @@ pub fn goto_declaration(
     };
 
     None
+}
+
+// ── Tree-sitter enhanced goto ──────────────────────────────────────────────
+
+/// Context extracted from the cursor position via tree-sitter.
+#[derive(Debug, Clone)]
+pub struct CursorContext {
+    /// The identifier text under the cursor.
+    pub name: String,
+    /// Enclosing function name (if any).
+    pub function: Option<String>,
+    /// Enclosing contract/interface/library name (if any).
+    pub contract: Option<String>,
+}
+
+/// Parse Solidity source with tree-sitter.
+fn ts_parse(source: &str) -> Option<tree_sitter::Tree> {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_solidity::LANGUAGE.into())
+        .expect("failed to load Solidity grammar");
+    parser.parse(source, None)
+}
+
+/// Find the deepest named node at the given byte offset.
+fn ts_node_at_byte(node: Node, byte: usize) -> Option<Node> {
+    if byte < node.start_byte() || byte >= node.end_byte() {
+        return None;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.start_byte() <= byte && byte < child.end_byte() {
+            if let Some(deeper) = ts_node_at_byte(child, byte) {
+                return Some(deeper);
+            }
+        }
+    }
+    Some(node)
+}
+
+/// Get the identifier name from a node (first `identifier` child or the node itself).
+fn ts_child_id_text<'a>(node: Node<'a>, source: &'a str) -> Option<&'a str> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|c| c.kind() == "identifier" && c.is_named())
+        .map(|c| &source[c.byte_range()])
+}
+
+/// Extract cursor context: the identifier under the cursor and its ancestor names.
+///
+/// Walks up the tree-sitter parse tree to find the enclosing function and contract.
+pub fn cursor_context(source: &str, position: Position) -> Option<CursorContext> {
+    let tree = ts_parse(source)?;
+    let byte = pos_to_bytes(source.as_bytes(), position);
+    let leaf = ts_node_at_byte(tree.root_node(), byte)?;
+
+    // The leaf should be an identifier (or we find the nearest identifier)
+    let id_node = if leaf.kind() == "identifier" {
+        leaf
+    } else {
+        // Check parent — cursor might be just inside a node that contains an identifier
+        let parent = leaf.parent()?;
+        if parent.kind() == "identifier" {
+            parent
+        } else {
+            return None;
+        }
+    };
+
+    let name = source[id_node.byte_range()].to_string();
+    let mut function = None;
+    let mut contract = None;
+
+    // Walk ancestors
+    let mut current = id_node.parent();
+    while let Some(node) = current {
+        match node.kind() {
+            "function_definition" | "modifier_definition" if function.is_none() => {
+                function = ts_child_id_text(node, source).map(String::from);
+            }
+            "constructor_definition" if function.is_none() => {
+                function = Some("constructor".into());
+            }
+            "contract_declaration" | "interface_declaration" | "library_declaration"
+                if contract.is_none() =>
+            {
+                contract = ts_child_id_text(node, source).map(String::from);
+            }
+            _ => {}
+        }
+        current = node.parent();
+    }
+
+    Some(CursorContext {
+        name,
+        function,
+        contract,
+    })
+}
+
+/// Information about a declaration found by tree-sitter.
+#[derive(Debug, Clone)]
+pub struct TsDeclaration {
+    /// Position range of the declaration identifier.
+    pub range: Range,
+    /// What kind of declaration (contract, function, state_variable, etc.).
+    pub kind: &'static str,
+    /// Container name (contract/struct that owns this declaration).
+    pub container: Option<String>,
+}
+
+/// Find all declarations of a name in a source file using tree-sitter.
+///
+/// Scans the parse tree for declaration nodes (state variables, functions, events,
+/// errors, structs, enums, contracts, etc.) whose identifier matches `name`.
+pub fn find_declarations_by_name(source: &str, name: &str) -> Vec<TsDeclaration> {
+    let tree = match ts_parse(source) {
+        Some(t) => t,
+        None => return vec![],
+    };
+    let mut results = Vec::new();
+    collect_declarations(tree.root_node(), source, name, None, &mut results);
+    results
+}
+
+fn collect_declarations(
+    node: Node,
+    source: &str,
+    name: &str,
+    container: Option<&str>,
+    out: &mut Vec<TsDeclaration>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if !child.is_named() {
+            continue;
+        }
+        match child.kind() {
+            "contract_declaration" | "interface_declaration" | "library_declaration" => {
+                if let Some(id_name) = ts_child_id_text(child, source) {
+                    if id_name == name {
+                        out.push(TsDeclaration {
+                            range: id_range(child),
+                            kind: child.kind(),
+                            container: container.map(String::from),
+                        });
+                    }
+                    // Recurse into contract body
+                    if let Some(body) = ts_find_child(child, "contract_body") {
+                        collect_declarations(body, source, name, Some(id_name), out);
+                    }
+                }
+            }
+            "function_definition" | "modifier_definition" => {
+                if let Some(id_name) = ts_child_id_text(child, source) {
+                    if id_name == name {
+                        out.push(TsDeclaration {
+                            range: id_range(child),
+                            kind: child.kind(),
+                            container: container.map(String::from),
+                        });
+                    }
+                    // Check function parameters
+                    collect_parameters(child, source, name, container, out);
+                    // Recurse into function body for local variables
+                    if let Some(body) = ts_find_child(child, "function_body") {
+                        collect_declarations(body, source, name, container, out);
+                    }
+                }
+            }
+            "constructor_definition" => {
+                if name == "constructor" {
+                    out.push(TsDeclaration {
+                        range: ts_range(child),
+                        kind: "constructor_definition",
+                        container: container.map(String::from),
+                    });
+                }
+                // Check constructor parameters
+                collect_parameters(child, source, name, container, out);
+                if let Some(body) = ts_find_child(child, "function_body") {
+                    collect_declarations(body, source, name, container, out);
+                }
+            }
+            "state_variable_declaration" | "variable_declaration" => {
+                if let Some(id_name) = ts_child_id_text(child, source) {
+                    if id_name == name {
+                        out.push(TsDeclaration {
+                            range: id_range(child),
+                            kind: child.kind(),
+                            container: container.map(String::from),
+                        });
+                    }
+                }
+            }
+            "struct_declaration" => {
+                if let Some(id_name) = ts_child_id_text(child, source) {
+                    if id_name == name {
+                        out.push(TsDeclaration {
+                            range: id_range(child),
+                            kind: "struct_declaration",
+                            container: container.map(String::from),
+                        });
+                    }
+                    if let Some(body) = ts_find_child(child, "struct_body") {
+                        collect_declarations(body, source, name, Some(id_name), out);
+                    }
+                }
+            }
+            "enum_declaration" => {
+                if let Some(id_name) = ts_child_id_text(child, source) {
+                    if id_name == name {
+                        out.push(TsDeclaration {
+                            range: id_range(child),
+                            kind: "enum_declaration",
+                            container: container.map(String::from),
+                        });
+                    }
+                    // Check enum values
+                    if let Some(body) = ts_find_child(child, "enum_body") {
+                        let mut ecur = body.walk();
+                        for val in body.children(&mut ecur) {
+                            if val.kind() == "enum_value" && &source[val.byte_range()] == name {
+                                out.push(TsDeclaration {
+                                    range: ts_range(val),
+                                    kind: "enum_value",
+                                    container: Some(id_name.to_string()),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            "event_definition" | "error_declaration" => {
+                if let Some(id_name) = ts_child_id_text(child, source) {
+                    if id_name == name {
+                        out.push(TsDeclaration {
+                            range: id_range(child),
+                            kind: child.kind(),
+                            container: container.map(String::from),
+                        });
+                    }
+                }
+            }
+            "user_defined_type_definition" => {
+                if let Some(id_name) = ts_child_id_text(child, source) {
+                    if id_name == name {
+                        out.push(TsDeclaration {
+                            range: id_range(child),
+                            kind: "user_defined_type_definition",
+                            container: container.map(String::from),
+                        });
+                    }
+                }
+            }
+            // Recurse into blocks, if-else, loops, etc.
+            _ => {
+                collect_declarations(child, source, name, container, out);
+            }
+        }
+    }
+}
+
+/// Collect parameter declarations from a function/constructor node.
+fn collect_parameters(
+    node: Node,
+    source: &str,
+    name: &str,
+    container: Option<&str>,
+    out: &mut Vec<TsDeclaration>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "parameter" {
+            if let Some(id_name) = ts_child_id_text(child, source) {
+                if id_name == name {
+                    out.push(TsDeclaration {
+                        range: id_range(child),
+                        kind: "parameter",
+                        container: container.map(String::from),
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Tree-sitter range helper.
+fn ts_range(node: Node) -> Range {
+    let s = node.start_position();
+    let e = node.end_position();
+    Range {
+        start: Position::new(s.row as u32, s.column as u32),
+        end: Position::new(e.row as u32, e.column as u32),
+    }
+}
+
+/// Get the range of the identifier child within a declaration node.
+fn id_range(node: Node) -> Range {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|c| c.kind() == "identifier" && c.is_named())
+        .map(|c| ts_range(c))
+        .unwrap_or_else(|| ts_range(node))
+}
+
+fn ts_find_child<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).find(|c| c.kind() == kind)
+}
+
+/// Tree-sitter enhanced goto definition.
+///
+/// Uses tree-sitter to find the identifier under the cursor and its scope,
+/// then resolves via the CompletionCache (for cross-file/semantic resolution),
+/// and finally uses tree-sitter to find the declaration position in the target file.
+///
+/// Falls back to None if resolution fails — caller should try the existing AST-based path.
+pub fn goto_definition_ts(
+    source: &str,
+    position: Position,
+    file_uri: &Url,
+    completion_cache: &crate::completion::CompletionCache,
+    text_cache: &HashMap<String, (i32, String)>,
+) -> Option<Location> {
+    let ctx = cursor_context(source, position)?;
+
+    // Step 1: Try to resolve via CompletionCache to find which file + name the declaration is in.
+    // Use the scope chain by names: find the contract scope, then resolve the name.
+    let resolved = resolve_via_cache(&ctx, file_uri, completion_cache);
+
+    match resolved {
+        Some(ResolvedTarget::SameFile) => {
+            // Declaration is in the same file — find it with tree-sitter
+            find_best_declaration(source, &ctx, file_uri)
+        }
+        Some(ResolvedTarget::OtherFile { path, name }) => {
+            // Declaration is in another file — read target source and find by name
+            let target_source = read_target_source(&path, text_cache);
+            let target_source = target_source?;
+            let target_uri = Url::from_file_path(&path).ok()?;
+            let decls = find_declarations_by_name(&target_source, &name);
+            decls.first().map(|d| Location {
+                uri: target_uri,
+                range: d.range,
+            })
+        }
+        None => {
+            // CompletionCache couldn't resolve — try same-file tree-sitter lookup as fallback
+            find_best_declaration(source, &ctx, file_uri)
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ResolvedTarget {
+    /// Declaration is in the same file as the usage.
+    SameFile,
+    /// Declaration is in a different file.
+    OtherFile { path: String, name: String },
+}
+
+/// Try to resolve an identifier using the CompletionCache.
+///
+/// Finds the scope by matching ancestor names (contract, function) against
+/// the cache's scope data, then resolves the name to a type and traces
+/// back to the declaring file.
+fn resolve_via_cache(
+    ctx: &CursorContext,
+    file_uri: &Url,
+    cache: &crate::completion::CompletionCache,
+) -> Option<ResolvedTarget> {
+    // Find the contract scope node_id by name
+    let contract_scope = ctx
+        .contract
+        .as_ref()
+        .and_then(|name| cache.name_to_node_id.get(name.as_str()))
+        .copied();
+
+    // Try scope-based resolution: look in the contract's scope_declarations
+    if let Some(contract_id) = contract_scope {
+        // Check function scope if we're inside one
+        if let Some(func_name) = &ctx.function {
+            // Find the function scope: look for a scope whose parent is this contract
+            // and which has a declaration for this function name
+            if let Some(func_scope_id) = find_function_scope(cache, contract_id, func_name) {
+                // Check declarations in this function scope first
+                if let Some(decls) = cache.scope_declarations.get(&func_scope_id) {
+                    if decls.iter().any(|d| d.name == ctx.name) {
+                        return Some(ResolvedTarget::SameFile);
+                    }
+                }
+            }
+        }
+
+        // Check contract scope declarations (state variables, functions)
+        if let Some(decls) = cache.scope_declarations.get(&contract_id) {
+            if decls.iter().any(|d| d.name == ctx.name) {
+                return Some(ResolvedTarget::SameFile);
+            }
+        }
+
+        // Check inherited contracts (C3 linearization)
+        if let Some(bases) = cache.linearized_base_contracts.get(&contract_id) {
+            for &base_id in bases.iter().skip(1) {
+                if let Some(decls) = cache.scope_declarations.get(&base_id) {
+                    if decls.iter().any(|d| d.name == ctx.name) {
+                        // Found in a base contract — find which file it's in
+                        // Reverse lookup: base_id → contract name → file
+                        let base_name = cache
+                            .name_to_node_id
+                            .iter()
+                            .find(|&(_, &id)| id == base_id)
+                            .map(|(name, _)| name.clone());
+
+                        if let Some(base_name) = base_name {
+                            if let Some(path) = find_file_for_contract(cache, &base_name, file_uri)
+                            {
+                                return Some(ResolvedTarget::OtherFile {
+                                    path,
+                                    name: ctx.name.clone(),
+                                });
+                            }
+                        }
+                        // Base contract might be in the same file
+                        return Some(ResolvedTarget::SameFile);
+                    }
+                }
+            }
+        }
+    }
+
+    // Check if the name is a contract/library/interface name
+    if cache.name_to_node_id.contains_key(&ctx.name) {
+        // Could be same file or different file — check if it's in the current file
+        if let Some(path) = find_file_for_contract(cache, &ctx.name, file_uri) {
+            let current_path = file_uri.to_file_path().ok()?;
+            let current_str = current_path.to_str()?;
+            if path == current_str || path.ends_with(current_str) || current_str.ends_with(&path) {
+                return Some(ResolvedTarget::SameFile);
+            }
+            return Some(ResolvedTarget::OtherFile {
+                path,
+                name: ctx.name.clone(),
+            });
+        }
+        return Some(ResolvedTarget::SameFile);
+    }
+
+    // Flat fallback — name_to_type knows about it but we can't determine the file
+    if cache.name_to_type.contains_key(&ctx.name) {
+        return Some(ResolvedTarget::SameFile);
+    }
+
+    None
+}
+
+/// Find the scope node_id for a function within a contract.
+fn find_function_scope(
+    cache: &crate::completion::CompletionCache,
+    contract_id: u64,
+    func_name: &str,
+) -> Option<u64> {
+    // Look for a scope whose parent is the contract and which is a function scope.
+    // The function name should appear as a declaration in the contract scope,
+    // and the function's own scope is the one whose parent is the contract.
+    for (&scope_id, &parent_id) in &cache.scope_parent {
+        if parent_id == contract_id {
+            // This scope's parent is our contract — it might be a function scope.
+            // Check if this scope has declarations (functions/blocks do).
+            // We also check if the contract declares a function with this name.
+            if let Some(contract_decls) = cache.scope_declarations.get(&contract_id) {
+                if contract_decls.iter().any(|d| d.name == func_name) {
+                    // Found a child scope of the contract — could be the function.
+                    // Check if this scope_id has child scopes or declarations
+                    // that match what we'd expect for a function body.
+                    if cache.scope_declarations.contains_key(&scope_id)
+                        || cache.scope_parent.values().any(|&p| p == scope_id)
+                    {
+                        return Some(scope_id);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Find the file path for a contract by searching the CompletionCache's path_to_file_id.
+fn find_file_for_contract(
+    cache: &crate::completion::CompletionCache,
+    contract_name: &str,
+    _file_uri: &Url,
+) -> Option<String> {
+    // The completion cache doesn't directly map contract → file.
+    // But scope_ranges + path_to_file_id can help.
+    // For now, check if the contract's node_id appears in any scope_range,
+    // then map file_id back to path.
+    let node_id = cache.name_to_node_id.get(contract_name)?;
+    let scope_range = cache.scope_ranges.iter().find(|r| r.node_id == *node_id)?;
+    let file_id = scope_range.file_id;
+
+    // Reverse lookup: file_id → path
+    cache
+        .path_to_file_id
+        .iter()
+        .find(|&(_, &fid)| fid == file_id)
+        .map(|(path, _)| path.clone())
+}
+
+/// Read source for a target file — prefer text_cache (open buffers), fallback to disk.
+fn read_target_source(path: &str, text_cache: &HashMap<String, (i32, String)>) -> Option<String> {
+    // Try text_cache by URI
+    let uri = Url::from_file_path(path).ok()?;
+    if let Some((_, content)) = text_cache.get(&uri.to_string()) {
+        return Some(content.clone());
+    }
+    // Fallback to disk
+    std::fs::read_to_string(path).ok()
+}
+
+/// Find the best matching declaration in the same file.
+fn find_best_declaration(source: &str, ctx: &CursorContext, file_uri: &Url) -> Option<Location> {
+    let decls = find_declarations_by_name(source, &ctx.name);
+    if decls.is_empty() {
+        return None;
+    }
+
+    // If there's only one declaration, use it
+    if decls.len() == 1 {
+        return Some(Location {
+            uri: file_uri.clone(),
+            range: decls[0].range,
+        });
+    }
+
+    // Multiple declarations — prefer the one in the same contract
+    if let Some(contract_name) = &ctx.contract {
+        if let Some(d) = decls
+            .iter()
+            .find(|d| d.container.as_deref() == Some(contract_name))
+        {
+            return Some(Location {
+                uri: file_uri.clone(),
+                range: d.range,
+            });
+        }
+    }
+
+    // Fallback: return first declaration
+    Some(Location {
+        uri: file_uri.clone(),
+        range: decls[0].range,
+    })
+}
+
+#[cfg(test)]
+mod ts_tests {
+    use super::*;
+
+    #[test]
+    fn test_cursor_context_state_var() {
+        let source = r#"
+contract Token {
+    uint256 public totalSupply;
+    function mint(uint256 amount) public {
+        totalSupply += amount;
+    }
+}
+"#;
+        // Cursor on `totalSupply` inside mint (line 4, col 8)
+        let ctx = cursor_context(source, Position::new(4, 8)).unwrap();
+        assert_eq!(ctx.name, "totalSupply");
+        assert_eq!(ctx.function.as_deref(), Some("mint"));
+        assert_eq!(ctx.contract.as_deref(), Some("Token"));
+    }
+
+    #[test]
+    fn test_cursor_context_top_level() {
+        let source = r#"
+contract Foo {}
+contract Bar {}
+"#;
+        // Cursor on `Foo` (line 1, col 9) — the identifier of the contract declaration
+        let ctx = cursor_context(source, Position::new(1, 9)).unwrap();
+        assert_eq!(ctx.name, "Foo");
+        assert!(ctx.function.is_none());
+        // The identifier `Foo` is a child of contract_declaration, so contract is set
+        assert_eq!(ctx.contract.as_deref(), Some("Foo"));
+    }
+
+    #[test]
+    fn test_find_declarations() {
+        let source = r#"
+contract Token {
+    uint256 public totalSupply;
+    function mint(uint256 amount) public {
+        totalSupply += amount;
+    }
+}
+"#;
+        let decls = find_declarations_by_name(source, "totalSupply");
+        assert_eq!(decls.len(), 1);
+        assert_eq!(decls[0].kind, "state_variable_declaration");
+        assert_eq!(decls[0].container.as_deref(), Some("Token"));
+    }
+
+    #[test]
+    fn test_find_declarations_multiple_contracts() {
+        let source = r#"
+contract A {
+    uint256 public value;
+}
+contract B {
+    uint256 public value;
+}
+"#;
+        let decls = find_declarations_by_name(source, "value");
+        assert_eq!(decls.len(), 2);
+        assert_eq!(decls[0].container.as_deref(), Some("A"));
+        assert_eq!(decls[1].container.as_deref(), Some("B"));
+    }
+
+    #[test]
+    fn test_find_declarations_enum_value() {
+        let source = "contract Foo { enum Status { Active, Paused } }";
+        let decls = find_declarations_by_name(source, "Active");
+        assert_eq!(decls.len(), 1);
+        assert_eq!(decls[0].kind, "enum_value");
+        assert_eq!(decls[0].container.as_deref(), Some("Status"));
+    }
+
+    #[test]
+    fn test_cursor_context_short_param() {
+        let source = r#"
+contract Shop {
+    uint256 public TAX;
+    constructor(uint256 price, uint16 tax, uint16 taxBase) {
+        TAX = tax;
+    }
+}
+"#;
+        // Cursor on `tax` usage at line 4, col 14 (TAX = tax;)
+        let ctx = cursor_context(source, Position::new(4, 14)).unwrap();
+        assert_eq!(ctx.name, "tax");
+        assert_eq!(ctx.contract.as_deref(), Some("Shop"));
+
+        // Cursor on `TAX` at line 4, col 8
+        let ctx2 = cursor_context(source, Position::new(4, 8)).unwrap();
+        assert_eq!(ctx2.name, "TAX");
+
+        // Parameters are found as declarations
+        let decls = find_declarations_by_name(source, "tax");
+        assert_eq!(decls.len(), 1);
+        assert_eq!(decls[0].kind, "parameter");
+
+        let decls_tax_base = find_declarations_by_name(source, "taxBase");
+        assert_eq!(decls_tax_base.len(), 1);
+        assert_eq!(decls_tax_base[0].kind, "parameter");
+
+        let decls_price = find_declarations_by_name(source, "price");
+        assert_eq!(decls_price.len(), 1);
+        assert_eq!(decls_price[0].kind, "parameter");
+
+        // State variable is also found
+        let decls_tax_upper = find_declarations_by_name(source, "TAX");
+        assert_eq!(decls_tax_upper.len(), 1);
+        assert_eq!(decls_tax_upper[0].kind, "state_variable_declaration");
+    }
+
+    #[test]
+    fn test_find_best_declaration_same_contract() {
+        let source = r#"
+contract A { uint256 public x; }
+contract B { uint256 public x; }
+"#;
+        let ctx = CursorContext {
+            name: "x".into(),
+            function: None,
+            contract: Some("B".into()),
+        };
+        let uri = Url::parse("file:///test.sol").unwrap();
+        let loc = find_best_declaration(source, &ctx, &uri).unwrap();
+        // Should pick B's x (line 2), not A's x (line 1)
+        assert_eq!(loc.range.start.line, 2);
+    }
 }


### PR DESCRIPTION
## Summary

- Tree-sitter enhanced go-to-definition that works with stale AST (files with errors)
- Fix formatting race condition causing stale text_cache after auto-format on save
- Parameter declaration support for function/constructor params

## Approach

Uses tree-sitter to resolve positions by **name** instead of byte offsets. Names don't shift when you edit code, byte offsets do.

1. Tree-sitter parses the live buffer → identifier name + ancestor scope (function, contract)
2. CompletionCache resolves the name semantically (scope chain, inheritance, cross-file)
3. Tree-sitter finds the declaration by name in the target file → exact current position
4. Falls back to existing AST-based goto if tree-sitter path fails

## Formatting fix

- `on_change` version guard prevents stale text overwriting newer formatted content
- Formatter updates `text_cache` immediately with formatted content

See `notes/GOTO.md` for detailed documentation.

Closes #66