### PR TITLE
feat: gas estimates in hover, inlay hints, and code lens

### DIFF
--- a/example/Shop.sol
+++ b/example/Shop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity ^0.8.0;
 
 //
 //                                                  █████
@@ -259,3 +259,5 @@ contract Shop {
         revert("Direct transfers not allowed");
     }
 }
+
+

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -373,14 +373,10 @@ pub fn build_completion_cache(sources: &Value, contracts: Option<&Value>) -> Com
     let mut linearized_base_contracts: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
 
     if let Some(sources_obj) = sources.as_object() {
-        for (path, contents) in sources_obj {
-            if let Some(contents_array) = contents.as_array()
-                && let Some(first_content) = contents_array.first()
-                && let Some(source_file) = first_content.get("source_file")
-                && let Some(ast) = source_file.get("ast")
-            {
+        for (path, source_data) in sources_obj {
+            if let Some(ast) = source_data.get("ast") {
                 // Map file path → source file id for scope resolution
-                if let Some(fid) = source_file.get("id").and_then(|v| v.as_u64()) {
+                if let Some(fid) = source_data.get("id").and_then(|v| v.as_u64()) {
                     path_to_file_id.insert(path.clone(), FileId(fid));
                 }
                 let mut stack: Vec<&Value> = vec![ast];
@@ -768,8 +764,7 @@ pub fn build_completion_cache(sources: &Value, contracts: Option<&Value>) -> Com
 
             if let Some(path_entry) = contracts_obj.get(path)
                 && let Some(contract_entry) = path_entry.get(contract_name)
-                && let Some(first) = contract_entry.get(0)
-                && let Some(evm) = first.get("contract").and_then(|c| c.get("evm"))
+                && let Some(evm) = contract_entry.get("evm")
                 && let Some(methods) = evm.get("methodIdentifiers")
                 && let Some(methods_obj) = methods.as_object()
             {

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -1,0 +1,483 @@
+//! Gas estimate extraction from solc contract output.
+//!
+//! Builds lookup tables from `contracts[path][name].contract.evm.gasEstimates`
+//! and `contracts[path][name].contract.evm.methodIdentifiers` so that hover,
+//! inlay hints, and code lenses can display gas costs.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Emoji prefix for gas estimate labels (inlay hints, code lens).
+pub const GAS_ICON: &str = "\u{1f525}";
+
+/// Gas estimates for a single contract.
+#[derive(Debug, Clone, Default)]
+pub struct ContractGas {
+    /// Deploy costs: `codeDepositCost`, `executionCost`, `totalCost`.
+    pub creation: HashMap<String, String>,
+    /// External function gas: selector → gas cost.
+    pub external: HashMap<String, String>,
+    /// Internal function gas: signature → gas cost.
+    pub internal: HashMap<String, String>,
+}
+
+/// All gas estimates indexed by (source_path, contract_name).
+pub type GasIndex = HashMap<String, ContractGas>;
+
+/// Build a gas index from normalized AST output.
+///
+/// The index key is `"path:ContractName"` (e.g. `"src/PoolManager.sol:PoolManager"`).
+/// For external functions, gas is also indexed by 4-byte selector for fast lookup
+/// from AST nodes that have `functionSelector`.
+///
+/// Expects the canonical shape: `contracts[path][name] = { abi, evm, ... }`.
+pub fn build_gas_index(ast_data: &Value) -> GasIndex {
+    let mut index = GasIndex::new();
+
+    let contracts = match ast_data.get("contracts").and_then(|c| c.as_object()) {
+        Some(c) => c,
+        None => return index,
+    };
+
+    for (path, names) in contracts {
+        let names_obj = match names.as_object() {
+            Some(n) => n,
+            None => continue,
+        };
+
+        for (name, contract) in names_obj {
+            let evm = match contract.get("evm") {
+                Some(e) => e,
+                None => continue,
+            };
+
+            let gas_estimates = match evm.get("gasEstimates") {
+                Some(g) => g,
+                None => continue,
+            };
+
+            let mut contract_gas = ContractGas::default();
+
+            // Creation costs
+            if let Some(creation) = gas_estimates.get("creation").and_then(|c| c.as_object()) {
+                for (key, value) in creation {
+                    let cost = value.as_str().unwrap_or("").to_string();
+                    contract_gas.creation.insert(key.clone(), cost);
+                }
+            }
+
+            // External function gas — also build selector → gas mapping
+            let method_ids = evm.get("methodIdentifiers").and_then(|m| m.as_object());
+
+            if let Some(external) = gas_estimates.get("external").and_then(|e| e.as_object()) {
+                // Build signature → selector reverse map
+                let sig_to_selector: HashMap<&str, &str> = method_ids
+                    .map(|mi| {
+                        mi.iter()
+                            .filter_map(|(sig, sel)| sel.as_str().map(|s| (sig.as_str(), s)))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                for (sig, value) in external {
+                    let cost = value.as_str().unwrap_or("").to_string();
+                    // Store by selector for fast AST node lookup
+                    if let Some(selector) = sig_to_selector.get(sig.as_str()) {
+                        contract_gas
+                            .external
+                            .insert(selector.to_string(), cost.clone());
+                    }
+                    // Also store by signature for display
+                    contract_gas.external.insert(sig.clone(), cost);
+                }
+            }
+
+            // Internal function gas
+            if let Some(internal) = gas_estimates.get("internal").and_then(|i| i.as_object()) {
+                for (sig, value) in internal {
+                    let cost = value.as_str().unwrap_or("").to_string();
+                    contract_gas.internal.insert(sig.clone(), cost);
+                }
+            }
+
+            let key = format!("{path}:{name}");
+            index.insert(key, contract_gas);
+        }
+    }
+
+    index
+}
+
+/// Look up gas cost for a function by its selector (external functions).
+pub fn gas_by_selector<'a>(index: &'a GasIndex, selector: &str) -> Option<(&'a str, &'a str)> {
+    for (contract_key, gas) in index {
+        if let Some(cost) = gas.external.get(selector) {
+            return Some((contract_key.as_str(), cost.as_str()));
+        }
+    }
+    None
+}
+
+/// Look up gas cost for an internal function by name.
+///
+/// Matches if the gas estimate key starts with `name(`.
+pub fn gas_by_name<'a>(index: &'a GasIndex, name: &str) -> Vec<(&'a str, &'a str, &'a str)> {
+    let prefix = format!("{name}(");
+    let mut results = Vec::new();
+    for (contract_key, gas) in index {
+        for (sig, cost) in &gas.internal {
+            if sig.starts_with(&prefix) {
+                results.push((contract_key.as_str(), sig.as_str(), cost.as_str()));
+            }
+        }
+    }
+    results
+}
+
+/// Look up creation/deploy gas for a contract.
+pub fn gas_for_contract<'a>(
+    index: &'a GasIndex,
+    path: &str,
+    name: &str,
+) -> Option<&'a ContractGas> {
+    let key = format!("{path}:{name}");
+    index.get(&key)
+}
+
+/// Resolve the gas index key for a declaration node.
+///
+/// Walks up through `scope` to find the containing `ContractDefinition`,
+/// then further to the `SourceUnit` to get `absolutePath`.
+/// Returns the `"path:ContractName"` key used in the gas index.
+pub fn resolve_contract_key(
+    sources: &Value,
+    decl_node: &Value,
+    index: &GasIndex,
+) -> Option<String> {
+    let node_type = decl_node.get("nodeType").and_then(|v| v.as_str())?;
+
+    // If this IS a ContractDefinition, find its source path directly
+    let (contract_name, source_id) = if node_type == "ContractDefinition" {
+        let name = decl_node.get("name").and_then(|v| v.as_str())?;
+        let scope_id = decl_node.get("scope").and_then(|v| v.as_u64())?;
+        (name.to_string(), scope_id)
+    } else {
+        // Walk up to containing contract
+        let scope_id = decl_node.get("scope").and_then(|v| v.as_u64())?;
+        let scope_node = crate::hover::find_node_by_id(sources, crate::types::NodeId(scope_id))?;
+        let contract_name = scope_node.get("name").and_then(|v| v.as_str())?;
+        let source_id = scope_node.get("scope").and_then(|v| v.as_u64())?;
+        (contract_name.to_string(), source_id)
+    };
+
+    // Find the SourceUnit to get the absolute path
+    let source_unit = crate::hover::find_node_by_id(sources, crate::types::NodeId(source_id))?;
+    let abs_path = source_unit.get("absolutePath").and_then(|v| v.as_str())?;
+
+    // Build the exact key
+    let exact_key = format!("{abs_path}:{contract_name}");
+    if index.contains_key(&exact_key) {
+        return Some(exact_key);
+    }
+
+    // Fallback: the gas index may use a different path representation.
+    // Match by suffix — find a key ending with the filename:ContractName.
+    let file_name = std::path::Path::new(abs_path).file_name()?.to_str()?;
+    let suffix = format!("{file_name}:{contract_name}");
+    index.keys().find(|k| k.ends_with(&suffix)).cloned()
+}
+
+/// Format a gas cost for display.
+/// Numbers get comma-separated (e.g. "6924600" → "6,924,600").
+/// "infinite" stays as-is.
+pub fn format_gas(cost: &str) -> String {
+    if cost == "infinite" {
+        return "infinite".to_string();
+    }
+    // Try to parse as number and format with commas
+    if let Ok(n) = cost.parse::<u64>() {
+        let s = n.to_string();
+        let mut result = String::new();
+        for (i, c) in s.chars().rev().enumerate() {
+            if i > 0 && i % 3 == 0 {
+                result.push(',');
+            }
+            result.push(c);
+        }
+        result.chars().rev().collect()
+    } else {
+        cost.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Load poolmanager.json (raw solc output) and normalize to canonical shape.
+    fn load_solc_fixture() -> Value {
+        let data = std::fs::read_to_string("poolmanager.json").expect("test fixture");
+        let raw: Value = serde_json::from_str(&data).expect("valid json");
+        crate::solc::normalize_solc_output(raw)
+    }
+
+    /// Load pool-manager-ast.json (forge output) and normalize to canonical shape.
+    fn load_forge_fixture() -> Value {
+        let data = std::fs::read_to_string("pool-manager-ast.json").expect("test fixture");
+        let raw: Value = serde_json::from_str(&data).expect("valid json");
+        crate::solc::normalize_forge_output(raw)
+    }
+
+    #[test]
+    fn test_format_gas_number() {
+        assert_eq!(format_gas("109"), "109");
+        assert_eq!(format_gas("2595"), "2,595");
+        assert_eq!(format_gas("6924600"), "6,924,600");
+        assert_eq!(format_gas("28088"), "28,088");
+    }
+
+    #[test]
+    fn test_format_gas_infinite() {
+        assert_eq!(format_gas("infinite"), "infinite");
+    }
+
+    #[test]
+    fn test_format_gas_unknown() {
+        assert_eq!(format_gas("unknown"), "unknown");
+    }
+
+    #[test]
+    fn test_build_gas_index_empty() {
+        let data = json!({});
+        let index = build_gas_index(&data);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn test_build_gas_index_no_contracts() {
+        let data = json!({ "sources": {}, "contracts": {} });
+        let index = build_gas_index(&data);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn test_build_gas_index_basic() {
+        let data = json!({
+            "contracts": {
+                "src/Foo.sol": {
+                    "Foo": {
+                        "evm": {
+                            "gasEstimates": {
+                                "creation": {
+                                    "codeDepositCost": "200",
+                                    "executionCost": "infinite",
+                                    "totalCost": "infinite"
+                                },
+                                "external": {
+                                    "bar(uint256)": "109"
+                                },
+                                "internal": {
+                                    "_baz(uint256)": "50"
+                                }
+                            },
+                            "methodIdentifiers": {
+                                "bar(uint256)": "abcd1234"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let index = build_gas_index(&data);
+        assert_eq!(index.len(), 1);
+
+        let foo = index.get("src/Foo.sol:Foo").unwrap();
+
+        // Creation
+        assert_eq!(foo.creation.get("codeDepositCost").unwrap(), "200");
+        assert_eq!(foo.creation.get("executionCost").unwrap(), "infinite");
+
+        // External — by selector
+        assert_eq!(foo.external.get("abcd1234").unwrap(), "109");
+        // External — by signature
+        assert_eq!(foo.external.get("bar(uint256)").unwrap(), "109");
+
+        // Internal
+        assert_eq!(foo.internal.get("_baz(uint256)").unwrap(), "50");
+    }
+
+    #[test]
+    fn test_gas_by_selector() {
+        let data = json!({
+            "contracts": {
+                "src/Foo.sol": {
+                    "Foo": {
+                        "evm": {
+                            "gasEstimates": {
+                                "external": { "bar(uint256)": "109" }
+                            },
+                            "methodIdentifiers": {
+                                "bar(uint256)": "abcd1234"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let index = build_gas_index(&data);
+        let (contract, cost) = gas_by_selector(&index, "abcd1234").unwrap();
+        assert_eq!(contract, "src/Foo.sol:Foo");
+        assert_eq!(cost, "109");
+    }
+
+    #[test]
+    fn test_gas_by_name() {
+        let data = json!({
+            "contracts": {
+                "src/Foo.sol": {
+                    "Foo": {
+                        "evm": {
+                            "gasEstimates": {
+                                "internal": {
+                                    "_baz(uint256)": "50",
+                                    "_baz(uint256,address)": "120"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let index = build_gas_index(&data);
+        let results = gas_by_name(&index, "_baz");
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_gas_for_contract() {
+        let data = json!({
+            "contracts": {
+                "src/Foo.sol": {
+                    "Foo": {
+                        "evm": {
+                            "gasEstimates": {
+                                "creation": {
+                                    "codeDepositCost": "6924600"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let index = build_gas_index(&data);
+        let gas = gas_for_contract(&index, "src/Foo.sol", "Foo").unwrap();
+        assert_eq!(gas.creation.get("codeDepositCost").unwrap(), "6924600");
+    }
+
+    #[test]
+    fn test_build_gas_index_from_forge_fixture() {
+        let ast = load_forge_fixture();
+        let index = build_gas_index(&ast);
+        // Forge fixture has no gasEstimates, just verify it doesn't crash
+        assert!(index.is_empty() || !index.is_empty());
+    }
+
+    #[test]
+    fn test_build_gas_index_from_solc_fixture() {
+        let ast = load_solc_fixture();
+        let index = build_gas_index(&ast);
+
+        // poolmanager.json has gas estimates for PoolManager
+        assert!(!index.is_empty(), "solc fixture should have gas data");
+
+        // Find PoolManager — keys have absolute paths
+        let pm_key = index
+            .keys()
+            .find(|k| k.contains("PoolManager.sol:PoolManager"))
+            .expect("should have PoolManager gas data");
+
+        let pm = index.get(pm_key).unwrap();
+
+        // Creation costs
+        assert!(
+            pm.creation.contains_key("codeDepositCost"),
+            "should have codeDepositCost"
+        );
+        assert!(
+            pm.creation.contains_key("executionCost"),
+            "should have executionCost"
+        );
+        assert!(
+            pm.creation.contains_key("totalCost"),
+            "should have totalCost"
+        );
+
+        // External functions
+        assert!(
+            !pm.external.is_empty(),
+            "should have external function gas estimates"
+        );
+
+        // Internal functions
+        assert!(
+            !pm.internal.is_empty(),
+            "should have internal function gas estimates"
+        );
+    }
+
+    #[test]
+    fn test_gas_by_selector_from_solc_fixture() {
+        let ast = load_solc_fixture();
+        let index = build_gas_index(&ast);
+
+        // owner() has selector "8da5cb5b" (well-known)
+        let result = gas_by_selector(&index, "8da5cb5b");
+        assert!(result.is_some(), "should find owner() by selector");
+        let (contract, cost) = result.unwrap();
+        assert!(
+            contract.contains("PoolManager"),
+            "should be PoolManager contract"
+        );
+        assert!(!cost.is_empty(), "should have a gas cost");
+    }
+
+    #[test]
+    fn test_gas_by_name_from_solc_fixture() {
+        let ast = load_solc_fixture();
+        let index = build_gas_index(&ast);
+
+        // _getPool is an internal function in PoolManager
+        let results = gas_by_name(&index, "_getPool");
+        assert!(!results.is_empty(), "should find _getPool internal gas");
+    }
+
+    #[test]
+    fn test_gas_for_contract_from_solc_fixture() {
+        let ast = load_solc_fixture();
+        let index = build_gas_index(&ast);
+
+        // Find the PoolManager key
+        let pm_key = index
+            .keys()
+            .find(|k| k.contains("PoolManager.sol:PoolManager"))
+            .expect("should have PoolManager");
+
+        // Parse the path and name from "path:Name"
+        let parts: Vec<&str> = pm_key.rsplitn(2, ':').collect();
+        let name = parts[0];
+        let path = parts[1];
+
+        let gas = gas_for_contract(&index, path, name);
+        assert!(gas.is_some(), "should find PoolManager contract gas");
+        assert_eq!(
+            gas.unwrap().creation.get("executionCost").unwrap(),
+            "infinite"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod completion;
 pub mod config;
+pub mod gas;
 pub mod goto;
 pub mod hover;
 pub mod inlay_hints;

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,5 +1,6 @@
 use crate::completion;
 use crate::config::{self, FoundryConfig, LintConfig};
+use crate::gas;
 use crate::goto;
 use crate::hover;
 use crate::inlay_hints;
@@ -328,6 +329,13 @@ impl ForgeLsp {
             }
         }
 
+        // Cache miss — if caller doesn't want to trigger a build, return None.
+        // This prevents inlay hints, code lens, etc. from blocking on a full
+        // solc/forge build. The cache will be populated by on_change (did_open/did_save).
+        if !insert_on_miss {
+            return None;
+        }
+
         // Cache miss — build the AST from disk.
         let path_str = file_path.to_str()?;
         let ast_result = if self.use_solc {
@@ -344,10 +352,8 @@ impl ForgeLsp {
                 // Built from disk (cache miss) — use version 0; the next
                 // didSave/on_change will stamp the correct version.
                 let build = Arc::new(goto::CachedBuild::new(data, 0));
-                if insert_on_miss {
-                    let mut cache = self.ast_cache.write().await;
-                    cache.insert(uri_str.clone(), build.clone());
-                }
+                let mut cache = self.ast_cache.write().await;
+                cache.insert(uri_str.clone(), build.clone());
                 Some(build)
             }
             Err(e) => {
@@ -467,6 +473,9 @@ impl LanguageServer for ForgeLsp {
                     },
                 }),
                 document_formatting_provider: Some(OneOf::Left(true)),
+                code_lens_provider: Some(CodeLensOptions {
+                    resolve_provider: Some(false),
+                }),
                 inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(
                     InlayHintOptions {
                         resolve_provider: Some(false),
@@ -1492,7 +1501,13 @@ impl LanguageServer for ForgeLsp {
             None => return Ok(None),
         };
 
-        let result = hover::hover_info(&cached_build.ast, &uri, position, &source_bytes);
+        let result = hover::hover_info(
+            &cached_build.ast,
+            &uri,
+            position,
+            &source_bytes,
+            &cached_build.gas_index,
+        );
 
         if result.is_some() {
             self.client
@@ -1639,6 +1654,132 @@ impl LanguageServer for ForgeLsp {
                 )
                 .await;
             Ok(Some(hints))
+        }
+    }
+
+    async fn code_lens(
+        &self,
+        params: CodeLensParams,
+    ) -> tower_lsp::jsonrpc::Result<Option<Vec<CodeLens>>> {
+        let uri = params.text_document.uri;
+
+        let file_path = match uri.to_file_path() {
+            Ok(path) => path,
+            Err(_) => return Ok(None),
+        };
+
+        let source_bytes = match self.get_source_bytes(&uri, &file_path).await {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+
+        let cached_build = self.get_or_fetch_build(&uri, &file_path, false).await;
+        let cached_build = match cached_build {
+            Some(cb) => cb,
+            None => return Ok(None),
+        };
+
+        let gas_index = &cached_build.gas_index;
+        if gas_index.is_empty() {
+            return Ok(None);
+        }
+
+        let sources = match cached_build.ast.get("sources") {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+
+        // Find the file's AST
+        let file_path_str = file_path.to_str().unwrap_or("");
+        let abs_path = cached_build
+            .path_to_abs
+            .iter()
+            .find(|(k, _)| file_path_str.ends_with(k.as_str()))
+            .map(|(_, v)| v.clone());
+
+        let abs = match abs_path {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        let file_ast = match sources.as_object().and_then(|obj| {
+            obj.iter()
+                .find(|(_, v)| {
+                    v.get("ast")
+                        .and_then(|ast| ast.get("absolutePath"))
+                        .and_then(|v| v.as_str())
+                        == Some(&abs)
+                })
+                .map(|(_, v)| v)
+        }) {
+            Some(s) => s.get("ast"),
+            None => None,
+        };
+
+        let file_ast = match file_ast {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        let text = String::from_utf8_lossy(&source_bytes);
+        let mut lenses = Vec::new();
+
+        // Walk top-level nodes for ContractDefinition
+        if let Some(nodes) = file_ast.get("nodes").and_then(|v| v.as_array()) {
+            for node in nodes {
+                let node_type = node.get("nodeType").and_then(|v| v.as_str()).unwrap_or("");
+                if node_type != "ContractDefinition" {
+                    continue;
+                }
+
+                if let Some(contract_key) = gas::resolve_contract_key(sources, node, gas_index) {
+                    if let Some(contract_gas) = gas_index.get(&contract_key) {
+                        if let Some(total) = contract_gas.creation.get("totalCost") {
+                            // Position: line above the contract definition
+                            if let Some(src) = node.get("src").and_then(|v| v.as_str()) {
+                                if let Some(loc) = crate::types::SourceLoc::parse(src) {
+                                    let pos =
+                                        crate::utils::byte_offset_to_position(&text, loc.offset);
+                                    let range = Range::new(pos, pos);
+
+                                    let code_deposit = contract_gas
+                                        .creation
+                                        .get("codeDepositCost")
+                                        .map(|s| gas::format_gas(s))
+                                        .unwrap_or_else(|| "?".to_string());
+                                    let execution = contract_gas
+                                        .creation
+                                        .get("executionCost")
+                                        .map(|s| gas::format_gas(s))
+                                        .unwrap_or_else(|| "?".to_string());
+
+                                    lenses.push(CodeLens {
+                                        range,
+                                        command: Some(Command {
+                                            title: format!(
+                                                "{} Deploy: {} (code: {}, exec: {})",
+                                                gas::GAS_ICON,
+                                                gas::format_gas(total),
+                                                code_deposit,
+                                                execution
+                                            ),
+                                            command: String::new(),
+                                            arguments: None,
+                                        }),
+                                        data: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if lenses.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(lenses))
         }
     }
 }

--- a/src/references.rs
+++ b/src/references.rs
@@ -201,15 +201,7 @@ pub fn goto_references_with_index(
         Some(s) => s,
         None => return vec![],
     };
-    let build_infos = match ast_data.get("build_infos").and_then(|v| v.as_array()) {
-        Some(infos) => infos,
-        None => return vec![],
-    };
-    let first_build_info = match build_infos.first() {
-        Some(info) => info,
-        None => return vec![],
-    };
-    let id_to_path = match first_build_info
+    let id_to_path = match ast_data
         .get("source_id_to_path")
         .and_then(|v| v.as_object())
     {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,4 +1,7 @@
-use crate::{build::build_output_to_diagnostics, lint::lint_output_to_diagnostics};
+use crate::{
+    build::build_output_to_diagnostics, lint::lint_output_to_diagnostics,
+    solc::normalize_forge_output,
+};
 use serde::{Deserialize, Serialize};
 use std::{io, path::PathBuf};
 use thiserror::Error;
@@ -88,7 +91,7 @@ impl Runner for ForgeRunner {
         let stdout_str = String::from_utf8_lossy(&output.stdout);
         let parsed: serde_json::Value = serde_json::from_str(&stdout_str)?;
 
-        Ok(parsed)
+        Ok(normalize_forge_output(parsed))
     }
 
     async fn format(&self, file_path: &str) -> Result<String, RunnerError> {

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -9,7 +9,9 @@ use std::fs;
 use tower_lsp::lsp_types::CompletionItemKind;
 
 fn load_ast() -> Value {
-    serde_json::from_str(&fs::read_to_string("pool-manager-ast.json").unwrap()).unwrap()
+    let raw: Value =
+        serde_json::from_str(&fs::read_to_string("pool-manager-ast.json").unwrap()).unwrap();
+    solidity_language_server::solc::normalize_forge_output(raw)
 }
 
 fn load_cache() -> solidity_language_server::completion::CompletionCache {

--- a/tests/cross_file_references.rs
+++ b/tests/cross_file_references.rs
@@ -7,8 +7,9 @@ use std::fs;
 
 /// Load pool-manager-ast.json as a CachedBuild.
 fn load_cached_build() -> CachedBuild {
-    let ast_data: Value =
+    let raw: Value =
         serde_json::from_str(&fs::read_to_string("pool-manager-ast.json").unwrap()).unwrap();
+    let ast_data = solidity_language_server::solc::normalize_forge_output(raw);
     CachedBuild::new(ast_data, 0)
 }
 
@@ -65,7 +66,7 @@ fn test_cached_build_has_external_refs() {
 fn test_cached_build_preserves_raw_ast() {
     let build = load_cached_build();
     assert!(build.ast.get("sources").is_some());
-    assert!(build.ast.get("build_infos").is_some());
+    assert!(build.ast.get("source_id_to_path").is_some());
 }
 
 // =============================================================================

--- a/tests/document_links.rs
+++ b/tests/document_links.rs
@@ -9,17 +9,16 @@ const PM_KEY: &str = "/Users/meek/developer/uniswap/v4-core/src/PoolManager.sol"
 
 /// Load the fixture as a CachedBuild.
 fn load_build() -> CachedBuild {
-    let ast: Value =
+    let raw: Value =
         serde_json::from_str(&fs::read_to_string("pool-manager-ast.json").unwrap()).unwrap();
+    let ast = solidity_language_server::solc::normalize_forge_output(raw);
     CachedBuild::new(ast, 0)
 }
 
-/// Extract ImportDirective nodes from the raw fixture AST.
+/// Extract ImportDirective nodes from the normalized fixture AST.
 /// Returns (src, file, absolutePath) tuples for verification.
 fn extract_imports(ast: &Value) -> Vec<(&str, &str, &str)> {
-    let nodes = ast["sources"][PM_KEY][0]["source_file"]["ast"]["nodes"]
-        .as_array()
-        .unwrap();
+    let nodes = ast["sources"][PM_KEY]["ast"]["nodes"].as_array().unwrap();
     nodes
         .iter()
         .filter(|n| n["nodeType"].as_str() == Some("ImportDirective"))

--- a/tests/yul_external_references.rs
+++ b/tests/yul_external_references.rs
@@ -10,10 +10,11 @@ type Type = (
     goto::ExternalRefs,
 );
 
-/// Load pool-manager-ast.json and run cache_ids.
+/// Load pool-manager-ast.json, normalize from forge shape, and run cache_ids.
 fn load_ast() -> Type {
-    let ast_data: Value =
+    let raw: Value =
         serde_json::from_str(&fs::read_to_string("pool-manager-ast.json").unwrap()).unwrap();
+    let ast_data = solidity_language_server::solc::normalize_forge_output(raw);
     let sources = ast_data.get("sources").unwrap();
     goto::cache_ids(sources)
 }
@@ -181,12 +182,11 @@ fn test_no_yul_src_keys_in_u64_map() {
 
 #[test]
 fn test_goto_bytes_resolves_yul_identifier() {
-    let ast_data: Value =
+    let raw: Value =
         serde_json::from_str(&fs::read_to_string("pool-manager-ast.json").unwrap()).unwrap();
+    let ast_data = solidity_language_server::solc::normalize_forge_output(raw);
     let sources = ast_data.get("sources").unwrap();
-    let build_infos = ast_data.get("build_infos").unwrap().as_array().unwrap();
-    let first_build_info = build_infos.first().unwrap();
-    let id_to_path_obj = first_build_info
+    let id_to_path_obj = ast_data
         .get("source_id_to_path")
         .unwrap()
         .as_object()
@@ -262,13 +262,11 @@ struct SetupGotoResult(
 
 /// Helper: set up goto_bytes inputs from the fixture.
 fn setup_goto() -> SetupGotoResult {
-    let ast_data: Value =
+    let raw: Value =
         serde_json::from_str(&fs::read_to_string("pool-manager-ast.json").unwrap()).unwrap();
+    let ast_data = solidity_language_server::solc::normalize_forge_output(raw);
     let sources = ast_data.get("sources").unwrap();
-    let build_infos = ast_data.get("build_infos").unwrap().as_array().unwrap();
-    let id_to_path: HashMap<String, String> = build_infos
-        .first()
-        .unwrap()
+    let id_to_path: HashMap<String, String> = ast_data
         .get("source_id_to_path")
         .unwrap()
         .as_object()


### PR DESCRIPTION
## Summary

Closes #91

- **Gas estimates** from solc output displayed in hover (functions + contracts), inlay hints (🔥 at opening braces), and code lens (deploy cost above contracts)
- **Solc-native canonical shape** — refactored away from forge's array-wrapping format to flat `sources[path]={id,ast}`, `contracts[path][name]={abi,evm,...}`
- **Non-blocking inlay hints** — pre-cache `HintIndex` in `CachedBuild` (O(1) lookups instead of O(n²) per-request AST walks), return empty on cache miss so navigation is never blocked

### New: `src/gas.rs`
- `GasIndex` built once per build from `contracts[path][name].evm.gasEstimates`
- Lookup by selector (external), name (internal), or contract key
- `resolve_contract_key()` walks AST scope chain to find containing contract
- `GAS_ICON` constant — single place to change the emoji

### Performance fixes
- `get_or_fetch_build` returns `None` immediately on cache miss when `insert_on_miss=false` — prevents inlay hints, code lens, hover from triggering a full solc/forge build
- `HintIndex` (parameter name lookups for all files) pre-computed in `CachedBuild::new()` — eliminates repeated O(total_nodes) walks per inlay hint request
- `build_id_index` replaces per-call `find_declaration` — single O(n) pass builds `HashMap<u64, &Value>`, then O(1) lookups

### 360 tests pass, 0 warnings