### PR TITLE
fix: use relative path in solc standard-json input to resolve imports

### DIFF
--- a/src/gas.rs
+++ b/src/gas.rs
@@ -228,7 +228,7 @@ mod tests {
     fn load_solc_fixture() -> Value {
         let data = std::fs::read_to_string("poolmanager.json").expect("test fixture");
         let raw: Value = serde_json::from_str(&data).expect("valid json");
-        crate::solc::normalize_solc_output(raw)
+        crate::solc::normalize_solc_output(raw, None)
     }
 
     /// Load pool-manager-ast.json (forge output) and normalize to canonical shape.

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -1678,7 +1678,7 @@ mod tests {
     fn load_solc_fixture() -> Value {
         let data = std::fs::read_to_string("poolmanager.json").expect("test fixture");
         let raw: Value = serde_json::from_str(&data).expect("valid json");
-        crate::solc::normalize_solc_output(raw)
+        crate::solc::normalize_solc_output(raw, None)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix false "No matching declaration found" errors for inherited members (e.g. `initPool` from `Deployers` in `ModifyLiquidity.t.sol`)
- Strip project root prefix from `file_path` in `solc_ast()` so solc receives a relative path instead of an absolute one
- Resolve relative paths back to absolute in `normalize_solc_output()` so goto/hover/links continue to work

## Root Cause

`build_standard_json_input` passed the absolute file path from the LSP URI into the `sources` field. Solc's import resolver behaves differently with absolute paths — it resolves **0 transitive imports**, so inherited members appear missing.

| | Absolute path | Relative path |
|---|---|---|
| Sources resolved | 0 | 91 |
| Contracts compiled | 0 | 88 |
| Errors | 1 (TypeError 9322) | 0 |

## Fix

Two-part change in `src/solc.rs`:

1. **`solc_ast()`** — strip `config.root` prefix to give solc a relative path (fixes import resolution)
2. **`normalize_solc_output(project_root)`** — resolve relative source/contract keys and AST `absolutePath` fields back to absolute (fixes goto/definition/links)

## Verification

Benchmark before fix:
```
code: 9322, message: "No matching declaration found after argument-dependent lookup."
definition: null
```

Benchmark after fix:
```
diagnostics: only lint warnings, 0 errors
definition: Deployers.sol line 152 (initPool)
hover: function initPool(Currency, Currency, IHooks, uint24, uint160) ...
```

405 tests pass, 0 failures.

Closes #101