### PR TITLE
feat: opt-in gas estimates via @custom:lsp-enable gas-estimates

### DIFF
--- a/example/Shop.sol
+++ b/example/Shop.sol
@@ -18,6 +18,7 @@ pragma solidity ^0.8.0;
 /// @title Transaction Library
 /// @author mmsaki
 /// @notice Utility library for computing tax and refund amounts on orders.
+/// @custom:lsp-enable gas-estimates
 library Transaction {
     /// @notice Represents a purchase order in the shop.
     /// @param buyer The address of the buyer who placed the order.
@@ -56,6 +57,7 @@ library Transaction {
 /// @author mmsaki
 /// @notice A simple e-commerce shop contract with tax, refunds, and two-step ownership transfer.
 /// @dev Uses the Transaction library for tax and refund calculations. Follows CEI pattern.
+/// @custom:lsp-enable gas-estimates
 contract Shop {
     using Transaction for uint256;
 

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -9,8 +9,9 @@ use std::collections::HashMap;
 
 use crate::types::{FuncSelector, MethodId};
 
-/// Emoji prefix for gas estimate labels (inlay hints, code lens).
-pub const GAS_ICON: &str = "\u{1f525}";
+/// Sentinel comment to enable gas estimates for a function.
+/// Place `/// @custom:lsp-enable gas-estimates` above a function definition.
+pub const GAS_SENTINEL: &str = "@custom:lsp-enable gas-estimates";
 
 /// Gas estimates for a single contract.
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Summary

Gas inlay hints and hover are now disabled by default. Add `/// @custom:lsp-enable gas-estimates` above a function or contract definition to opt in.

- Removed fire emoji from gas labels
- Inlay hints show `gas: 125,432` (functions) and `deploy: 6,924,600` (contracts)
- Tree-sitter sentinel detection for inlay hints, source-based detection for hover
- 3 new tests for sentinel present/absent/with-other-natspec

Closes #107