### PR TITLE
perf: reduce cold start from 14s to 2s by optimizing solc input

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -479,6 +479,14 @@ impl LanguageServer for ForgeLsp {
                     ),
                 )
                 .await;
+            if foundry_cfg.via_ir {
+                self.client
+                    .log_message(
+                        MessageType::WARNING,
+                        "via_ir is enabled in foundry.toml — gas estimate inlay hints are disabled to avoid slow compilation",
+                    )
+                    .await;
+            }
             let mut fc = self.foundry_config.write().await;
             *fc = foundry_cfg;
         }
@@ -876,6 +884,14 @@ impl LanguageServer for ForgeLsp {
                         ),
                     )
                     .await;
+                if foundry_cfg.via_ir {
+                    self.client
+                        .log_message(
+                            MessageType::WARNING,
+                            "via_ir is enabled in foundry.toml — gas estimate inlay hints are disabled to avoid slow compilation",
+                        )
+                        .await;
+                }
                 let mut fc = self.foundry_config.write().await;
                 *fc = foundry_cfg;
                 break;


### PR DESCRIPTION
## Summary

- Stop passing `optimizer` settings to solc — adds ~3s and doesn't affect AST, ABI, or documentation quality
- Conditionally exclude `evm.gasEstimates` from `outputSelection` when `via_ir` is enabled — requesting gas estimates with viaIR forces solc through the full Yul IR codegen pipeline (~14s), without viaIR it costs only ~0.7s
- Gas inlay hints continue to work normally for non-viaIR projects
- Warn users via `window/logMessage` when `via_ir` is detected

## Benchmark (PoolManager.t.sol cold start)

| Config | Cold Start |
|--------|-----------|
| Before (viaIR + gasEstimates + optimizer) | **14.6s** |
| After (viaIR, no gasEstimates, no optimizer) | **2.3s** |

## Solc profiling

| Setting | Time |
|---------|------|
| AST only | 1.8s |
| viaIR + AST only | 1.8s |
| viaIR + abi/devdoc/userdoc/methodIds | 1.8s |
| viaIR + gasEstimates | **14.0s** |
| viaIR + all outputs + optimizer | **26.5s** |

The root cause is `evm.gasEstimates + viaIR` — this combination forces solc through full Yul IR codegen. viaIR alone is free.