### PR TITLE
perf: documentLink returns only import links (83x faster)

### DIFF
--- a/src/links.rs
+++ b/src/links.rs
@@ -1,15 +1,12 @@
 use crate::goto::{CachedBuild, bytes_to_pos};
-use crate::references::id_to_location;
 use crate::types::SourceLoc;
 use tower_lsp::lsp_types::{DocumentLink, Range, Url};
 
-/// Extract document links for every node in the current file that
-/// references a declaration elsewhere.
+/// Extract document links for import directives in the current file.
 ///
-/// For `ImportDirective` nodes, the link covers the import path string
-/// and targets the imported file. For all other nodes with a
-/// `referencedDeclaration`, the link covers the node's name and targets
-/// the declaration's location.
+/// Each `ImportDirective` node produces a clickable link over the import
+/// path string that targets the imported file. Other identifier links
+/// are handled by `textDocument/definition`.
 pub fn document_links(
     build: &CachedBuild,
     file_uri: &Url,
@@ -36,54 +33,12 @@ pub fn document_links(
         None => return links,
     };
 
-    let tmp = file_nodes.iter();
-    for (_id, node_info) in tmp {
-        // ImportDirective: link the import path to the imported file
+    for (_id, node_info) in file_nodes.iter() {
         if node_info.node_type.as_deref() == Some("ImportDirective") {
             if let Some(link) = import_link(node_info, source_bytes) {
                 links.push(link);
             }
-            continue;
         }
-
-        // Any node with a referencedDeclaration: link to that declaration
-        let ref_id = match node_info.referenced_declaration {
-            Some(id) => id,
-            None => continue,
-        };
-
-        // Use name_location if available, otherwise fall back to src
-        let loc_str = node_info.name_location.as_deref().unwrap_or(&node_info.src);
-        let src_loc = match SourceLoc::parse(loc_str) {
-            Some(loc) => loc,
-            None => continue,
-        };
-        let (start_byte, length) = (src_loc.offset, src_loc.length);
-
-        let start_pos = match bytes_to_pos(source_bytes, start_byte) {
-            Some(p) => p,
-            None => continue,
-        };
-        let end_pos = match bytes_to_pos(source_bytes, start_byte + length) {
-            Some(p) => p,
-            None => continue,
-        };
-
-        // Resolve the target declaration to a file location
-        let target_location = match id_to_location(&build.nodes, &build.id_to_path_map, ref_id) {
-            Some(loc) => loc,
-            None => continue,
-        };
-
-        links.push(DocumentLink {
-            range: Range {
-                start: start_pos,
-                end: end_pos,
-            },
-            target: Some(target_location.uri),
-            tooltip: None,
-            data: None,
-        });
     }
 
     links.sort_by(|a, b| {


### PR DESCRIPTION
## Summary

- documentLink was iterating every AST node and creating a link for each `referencedDeclaration`, essentially duplicating `textDocument/definition` for every identifier in the file
- Now only emits links for `ImportDirective` nodes — the actual clickable import paths

## Benchmark (Pool.sol, 613 lines, 14 imports)

| | Before | After |
|---|---|---|
| Mean | 58.4ms | 0.7ms |
| Links returned | 753 | 14 |

**83x faster**, returning only the 14 actual import links instead of 753 identifier links.