### PR TITLE
feat: full project indexing with async background index and progress reporting

### DIFF
--- a/benchmarks/poolmanager-t-diag.yaml
+++ b/benchmarks/poolmanager-t-diag.yaml
@@ -1,0 +1,15 @@
+# PoolManager.t.sol — diagnostics-only benchmark
+#   lsp-bench -c benchmarks/poolmanager-t-diag.yaml
+
+project: v4-core
+file: test/PoolManager.t.sol
+line: 116
+col: 51
+output: benchmarks/poolmanager-t-diag
+report: README.md
+
+servers:
+  - mmsaki@latest
+
+benchmarks:
+  - textDocument/diagnostic


### PR DESCRIPTION
## Summary

Expand project-wide source indexing to include **all** user-authored Solidity files (test, script) — not just `src/` — so find-references and rename discover usages across the entire project. The project index now runs asynchronously in the background after diagnostics are published, with `window/workDoneProgress` reporting.

Closes #139. Builds on #115 / #119.

## Changes

- **`src/solc.rs`** — Replace `SKIP_DIRS` with `ALWAYS_SKIP_DIRS` (`node_modules`, `out`, `artifacts`, `cache`) + user-configured `libs`. Remove `.t.sol`/`.s.sol` suffix filter. Walk full project root instead of just `sources_dir`.
- **`src/config.rs`** — Add `libs` field to `FoundryConfig`, parsed from `libs = ["lib"]` in `foundry.toml` (default: `["lib"]`). Add 2 unit tests.
- **`src/lsp.rs`** — Publish diagnostics immediately, then spawn the project index in a background `tokio::spawn` task. Add `window/workDoneProgress` reporting ("Indexing project — Discovering source files...") with begin/end notifications.
- **`benchmarks/poolmanager-t-diag.yaml`** — New diagnostics-only benchmark config for `PoolManager.t.sol`.

## Benchmark (`PoolManager.t.sol` diagnostics, v4-core)

| | Sync index | Async index | Delta |
|--|--|--|--|
| **p50** | 5.15s | **1.98s** | **-3.17s (61% faster)** |
| **p95** | 5.20s | **2.00s** | **-3.20s** |
| **RSS** | 432.9 MB | **255.0 MB** | **-178 MB (41% less)** |
| **Diagnostics** | 15 | 15 | Same |

Diagnostics are no longer blocked by the project index. The user sees diagnostics in ~2.0s (same as before this feature), and the project index builds in the background with a status bar spinner. Find-references and rename gain full project coverage once the index completes.