### PR TITLE
Add projectIndex.fullProjectScan setting (default false)

### DIFF
--- a/docs/pages/docs/features.md
+++ b/docs/pages/docs/features.md
@@ -1,0 +1,88 @@
+## Features
+
+- **Go to Definition** / **Go to Declaration** — jump to any symbol across files
+- **Find References** — all usages of a symbol across the project
+- **Rename** — project-wide symbol rename with prepare support
+- **Hover** — signatures, NatSpec docs, function/error/event selectors, `@inheritdoc` resolution
+- **Completions** — scope-aware with two modes (fast cache vs full recomputation)
+- **Document Links** — clickable imports, type names, function calls
+- **Document Symbols** / **Workspace Symbols** — outline and search
+- **Formatting** — via `forge fmt`
+- **Diagnostics** — from `solc` and `forge lint`
+- **Signature Help** — parameter info on function calls, event emits, and mapping access
+- **Inlay Hints** — parameter names and gas estimates
+- **File Operations** — `workspace/willCreateFiles` scaffolding + `workspace/willRenameFiles`/`workspace/willDeleteFiles` import edits + `workspace/didCreateFiles`/`workspace/didRenameFiles`/`workspace/didDeleteFiles` cache migration/re-index (`fileOperations.templateOnCreate`, `fileOperations.updateImportsOnRename`, `fileOperations.updateImportsOnDelete`)
+- **Project Indexing Mode** — optional full-project indexing via `projectIndex.fullProjectScan` (available in versions newer than `v0.1.26`)
+
+### LSP Methods
+
+**General**
+
+- [x] `initialize` - Server initialization
+- [x] `initialized` - Server initialized notification
+- [x] `shutdown` - Server shutdown
+
+**Text Synchronization**
+
+- [x] `textDocument/didOpen` - Handle file opening
+- [x] `textDocument/didChange` - Handle file content changes
+- [x] `textDocument/didSave` - Handle file saving with diagnostics refresh
+- [x] `textDocument/didClose` - Handle file closing
+- [x] `textDocument/willSave` - File will save notification
+- [ ] `textDocument/willSaveWaitUntil` - File will save wait until
+
+**Diagnostics**
+
+- [x] `textDocument/publishDiagnostics` - Publish compilation errors and warnings via `forge build`
+- [x] `textDocument/publishDiagnostics` - Publish linting errors and warnings via `forge lint`
+
+**Language Features**
+
+- [x] `textDocument/definition` - Go to definition
+- [x] `textDocument/declaration` - Go to declaration
+- [x] `textDocument/references` - Find all references
+- [x] `textDocument/documentSymbol` - Document symbol outline (contracts, functions, variables, events, structs, enums, etc.)
+- [x] `textDocument/prepareRename` - Prepare rename validation
+- [x] `textDocument/rename` - Rename symbols across files
+- [x] `textDocument/formatting` - Document formatting
+- [x] `textDocument/completion` - Code completion
+- [x] `textDocument/hover` - Hover information
+- [x] `textDocument/signatureHelp` - Function signature help (functions, events, mappings)
+- [ ] `textDocument/typeDefinition` - Go to type definition
+- [ ] `textDocument/implementation` - Go to implementation
+- [x] `textDocument/documentHighlight` - Document highlighting (read/write classification)
+- [ ] `textDocument/codeAction` - Code actions (quick fixes, refactoring)
+- [ ] `textDocument/codeLens` - Code lens
+- [x] `textDocument/documentLink` - Document links (clickable references and import paths)
+- [ ] `textDocument/documentColor` - Color information
+- [ ] `textDocument/colorPresentation` - Color presentation
+- [ ] `textDocument/rangeFormatting` - Range formatting
+- [ ] `textDocument/onTypeFormatting` - On-type formatting
+- [x] `textDocument/foldingRange` - Folding ranges (contracts, functions, structs, enums, blocks, comments, imports)
+- [x] `textDocument/selectionRange` - Selection ranges
+- [x] `textDocument/inlayHint` - Inlay hints (parameter names, gas estimates)
+- [x] `textDocument/semanticTokens` - Semantic tokens
+- [x] `textDocument/semanticTokens/full` - Full semantic tokens
+- [x] `textDocument/semanticTokens/range` - Range semantic tokens
+- [x] `textDocument/semanticTokens/delta` - Delta semantic tokens
+
+**Workspace Features**
+
+- [x] `workspace/symbol` - Workspace-wide symbol search
+- [x] `workspace/didChangeConfiguration` - Updates editor settings (inlay hints, lint options)
+- [x] `workspace/didChangeWatchedFiles` - Acknowledges watched file changes (logs only)
+- [x] `workspace/didChangeWorkspaceFolders` - Acknowledges workspace folder changes (logs only)
+- [ ] `workspace/applyEdit` - Inbound handler not implemented (server uses outbound `workspace/applyEdit` to scaffold created files)
+- [ ] `workspace/executeCommand` - Execute workspace commands (stub implementation)
+- [x] `workspace/willCreateFiles` - File creation preview (scaffolding for `.sol`, `.t.sol`, `.s.sol`)
+- [x] `workspace/didCreateFiles` - Post-create scaffold fallback + cache/index refresh
+- [x] `workspace/willRenameFiles` - File rename preview (import path updates)
+- [x] `workspace/didRenameFiles` - Post-rename cache migration + background re-index
+- [x] `workspace/willDeleteFiles` - File deletion preview (removes imports to deleted files)
+- [x] `workspace/didDeleteFiles` - Post-delete cache cleanup + background re-index
+
+**Window Features**
+
+- [ ] `window/showMessage` - Show message to user
+- [ ] `window/showMessageRequest` - Show message request to user
+- [x] `window/workDoneProgress` - Work done progress

--- a/docs/pages/setup/index.mdx
+++ b/docs/pages/setup/index.mdx
@@ -1,0 +1,62 @@
+# Editor Setup
+
+All editor configs support the same server settings.
+
+## Full settings schema
+
+```json [settings.json]
+{
+  "solidity-language-server": {
+    "inlayHints": {
+      "parameters": true,
+      "gasEstimates": true
+    },
+    "lint": {
+      "enabled": true,
+      "severity": [],
+      "only": [],
+      "exclude": []
+    },
+    "fileOperations": {
+      "templateOnCreate": true,
+      "updateImportsOnRename": true,
+      "updateImportsOnDelete": true
+    },
+    "projectIndex": {
+      "fullProjectScan": false
+    }
+  }
+}
+```
+
+## Lint values
+
+Foundry lint config reference (lint_on_build): [Foundry linter config docs](https://www.getfoundry.sh/config/reference/linter#lint_on_build)
+
+- `lint.severity`: `"high"`, `"med"`, `"low"`, `"info"`, `"gas"`, `"code-size"`
+- `lint.only` / `lint.exclude` rule IDs:
+  - `incorrect-shift`
+  - `unchecked-call`
+  - `erc20-unchecked-transfer`
+  - `divide-before-multiply`
+  - `unsafe-typecast`
+  - `pascal-case-struct`
+  - `mixed-case-function`
+  - `mixed-case-variable`
+  - `screaming-snake-case-const`
+  - `screaming-snake-case-immutable`
+  - `unused-import`
+  - `unaliased-plain-import`
+  - `named-struct-fields`
+  - `unsafe-cheatcode`
+  - `asm-keccak256`
+  - `custom-errors`
+  - `unwrapped-modifier-logic`
+
+## Notes
+
+- Empty arrays for `severity`, `only`, `exclude` mean "no filter".
+- Defaults are all enabled (`true`) with empty lint arrays.
+- `projectIndex.fullProjectScan` defaults to `false` to keep startup latency low.
+- `projectIndex.fullProjectScan` is available only in versions newer than `v0.1.26` (`v0.1.27+`).
+- For file rename workflows, editors may require explicit save-all to persist buffer edits to disk.

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,8 @@ pub struct Settings {
     pub lint: LintSettings,
     #[serde(default)]
     pub file_operations: FileOperationsSettings,
+    #[serde(default)]
+    pub project_index: ProjectIndexSettings,
 }
 
 /// Inlay-hint settings.
@@ -106,6 +108,24 @@ impl Default for FileOperationsSettings {
             template_on_create: true,
             update_imports_on_rename: true,
             update_imports_on_delete: true,
+        }
+    }
+}
+
+/// Project indexing feature settings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectIndexSettings {
+    /// If true, run a full-project index scan at startup / first successful build.
+    /// If false (default), skip eager full-project scanning for faster startup.
+    #[serde(default)]
+    pub full_project_scan: bool,
+}
+
+impl Default for ProjectIndexSettings {
+    fn default() -> Self {
+        Self {
+            full_project_scan: false,
         }
     }
 }
@@ -923,6 +943,7 @@ src = "src"
         assert!(s.file_operations.template_on_create);
         assert!(s.file_operations.update_imports_on_rename);
         assert!(s.file_operations.update_imports_on_delete);
+        assert!(!s.project_index.full_project_scan);
         assert!(s.lint.severity.is_empty());
         assert!(s.lint.only.is_empty());
         assert!(s.lint.exclude.is_empty());
@@ -944,6 +965,9 @@ src = "src"
                     "updateImportsOnRename": false,
                     "updateImportsOnDelete": false
                 },
+                "projectIndex": {
+                    "fullProjectScan": true
+                },
             }
         });
         let s = parse_settings(&value);
@@ -953,6 +977,7 @@ src = "src"
         assert!(!s.file_operations.template_on_create);
         assert!(!s.file_operations.update_imports_on_rename);
         assert!(!s.file_operations.update_imports_on_delete);
+        assert!(s.project_index.full_project_scan);
         assert_eq!(s.lint.severity, vec!["high", "med"]);
         assert_eq!(s.lint.only, vec!["incorrect-shift"]);
         assert_eq!(
@@ -970,6 +995,9 @@ src = "src"
                 "templateOnCreate": false,
                 "updateImportsOnRename": false,
                 "updateImportsOnDelete": false
+            },
+            "projectIndex": {
+                "fullProjectScan": true
             }
         });
         let s = parse_settings(&value);
@@ -978,6 +1006,7 @@ src = "src"
         assert!(!s.file_operations.template_on_create);
         assert!(!s.file_operations.update_imports_on_rename);
         assert!(!s.file_operations.update_imports_on_delete);
+        assert!(s.project_index.full_project_scan);
     }
 
     #[test]
@@ -996,6 +1025,7 @@ src = "src"
         assert!(s.file_operations.template_on_create);
         assert!(s.file_operations.update_imports_on_rename);
         assert!(s.file_operations.update_imports_on_delete);
+        assert!(!s.project_index.full_project_scan);
         assert!(s.lint.severity.is_empty());
         assert!(s.lint.only.is_empty());
         assert_eq!(s.lint.exclude, vec!["unused-import"]);
@@ -1013,6 +1043,7 @@ src = "src"
         assert!(s.file_operations.template_on_create);
         assert!(s.file_operations.update_imports_on_rename);
         assert!(s.file_operations.update_imports_on_delete);
+        assert!(!s.project_index.full_project_scan);
         assert!(s.lint.severity.is_empty());
         assert!(s.lint.only.is_empty());
         assert!(s.lint.exclude.is_empty());

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -372,6 +372,7 @@ impl ForgeLsp {
         // so the user sees diagnostics immediately without waiting for the index.
         if build_succeeded
             && self.use_solc
+            && self.settings.read().await.project_index.full_project_scan
             && !self
                 .project_indexed
                 .load(std::sync::atomic::Ordering::Relaxed)
@@ -589,8 +590,8 @@ impl LanguageServer for ForgeLsp {
                 .log_message(
                     MessageType::INFO,
                     format!(
-                        "settings: inlayHints.parameters={}, inlayHints.gasEstimates={}, lint.enabled={}, lint.severity={:?}, lint.only={:?}, lint.exclude={:?}, fileOperations.templateOnCreate={}, fileOperations.updateImportsOnRename={}, fileOperations.updateImportsOnDelete={}",
-                        s.inlay_hints.parameters, s.inlay_hints.gas_estimates, s.lint.enabled, s.lint.severity, s.lint.only, s.lint.exclude, s.file_operations.template_on_create, s.file_operations.update_imports_on_rename, s.file_operations.update_imports_on_delete,
+                        "settings: inlayHints.parameters={}, inlayHints.gasEstimates={}, lint.enabled={}, lint.severity={:?}, lint.only={:?}, lint.exclude={:?}, fileOperations.templateOnCreate={}, fileOperations.updateImportsOnRename={}, fileOperations.updateImportsOnDelete={}, projectIndex.fullProjectScan={}",
+                        s.inlay_hints.parameters, s.inlay_hints.gas_estimates, s.lint.enabled, s.lint.severity, s.lint.only, s.lint.exclude, s.file_operations.template_on_create, s.file_operations.update_imports_on_rename, s.file_operations.update_imports_on_delete, s.project_index.full_project_scan,
                     ),
                 )
                 .await;
@@ -900,7 +901,7 @@ impl LanguageServer for ForgeLsp {
         // Eagerly build the project index on startup so cross-file features
         // (willRenameFiles, references, goto) work immediately — even before
         // the user opens any .sol file.
-        if self.use_solc {
+        if self.use_solc && self.settings.read().await.project_index.full_project_scan {
             self.project_indexed
                 .store(true, std::sync::atomic::Ordering::Relaxed);
             let foundry_config = self.foundry_config.read().await.clone();
@@ -1359,8 +1360,8 @@ impl LanguageServer for ForgeLsp {
                 .log_message(
                     MessageType::INFO,
                     format!(
-                    "settings updated: inlayHints.parameters={}, inlayHints.gasEstimates={}, lint.enabled={}, lint.severity={:?}, lint.only={:?}, lint.exclude={:?}, fileOperations.templateOnCreate={}, fileOperations.updateImportsOnRename={}, fileOperations.updateImportsOnDelete={}",
-                    s.inlay_hints.parameters, s.inlay_hints.gas_estimates, s.lint.enabled, s.lint.severity, s.lint.only, s.lint.exclude, s.file_operations.template_on_create, s.file_operations.update_imports_on_rename, s.file_operations.update_imports_on_delete,
+                    "settings updated: inlayHints.parameters={}, inlayHints.gasEstimates={}, lint.enabled={}, lint.severity={:?}, lint.only={:?}, lint.exclude={:?}, fileOperations.templateOnCreate={}, fileOperations.updateImportsOnRename={}, fileOperations.updateImportsOnDelete={}, projectIndex.fullProjectScan={}",
+                    s.inlay_hints.parameters, s.inlay_hints.gas_estimates, s.lint.enabled, s.lint.severity, s.lint.only, s.lint.exclude, s.file_operations.template_on_create, s.file_operations.update_imports_on_rename, s.file_operations.update_imports_on_delete, s.project_index.full_project_scan,
                 ),
             )
             .await;


### PR DESCRIPTION
## Summary
- add new setting: `projectIndex.fullProjectScan` (default `false`)
- gate full-project indexing behind this setting
  - startup eager index path
  - first-successful-build background project index path
- include `projectIndex.fullProjectScan` in settings log output
- document setting in setup schema and features docs

## Why
This gives users explicit control over startup indexing cost vs immediate cross-file coverage in large projects.

## Validation
- `cargo build --release`
- `cargo test test_parse_settings -- --nocapture`

## Issues
- Closes #150