### PR TITLE
fix: stabilize references cache and make indexing non-blocking

### DIFF
--- a/src/project_cache.rs
+++ b/src/project_cache.rs
@@ -136,6 +136,10 @@ fn keccak_hex(bytes: &[u8]) -> String {
     hex::encode(out)
 }
 
+fn src_file_id(src: &str) -> Option<&str> {
+    src.rsplit(':').next().filter(|id| !id.is_empty())
+}
+
 fn file_hash(path: &Path) -> Option<String> {
     let bytes = fs::read(path).ok()?;
     Some(keccak_hex(&bytes))
@@ -146,6 +150,64 @@ fn relative_to_root(root: &Path, file: &Path) -> String {
         .unwrap_or(file)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+fn normalize_path_to_abs_metadata(
+    root: &Path,
+    path_to_abs: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut out = HashMap::with_capacity(path_to_abs.len());
+    for (k, v) in path_to_abs {
+        let rel_key = if Path::new(k).is_absolute() {
+            relative_to_root(root, Path::new(k))
+        } else {
+            k.replace('\\', "/")
+        };
+        let abs_val = if Path::new(v).is_absolute() {
+            v.clone()
+        } else {
+            root.join(v).to_string_lossy().to_string()
+        };
+        out.insert(rel_key, abs_val);
+    }
+    out
+}
+
+fn runtime_path_to_abs_map(
+    root: &Path,
+    persisted: &HashMap<String, String>,
+    nodes: &HashMap<String, HashMap<NodeId, NodeInfo>>,
+) -> HashMap<String, String> {
+    let mut out = HashMap::with_capacity(persisted.len() * 2 + nodes.len());
+
+    for (k, v) in persisted {
+        let rel_key = if Path::new(k).is_absolute() {
+            relative_to_root(root, Path::new(k))
+        } else {
+            k.replace('\\', "/")
+        };
+        let abs_key = if Path::new(k).is_absolute() {
+            k.clone()
+        } else {
+            root.join(k).to_string_lossy().to_string()
+        };
+        let abs_val = if Path::new(v).is_absolute() {
+            v.clone()
+        } else {
+            root.join(v).to_string_lossy().to_string()
+        };
+        out.insert(rel_key, abs_val.clone());
+        out.insert(abs_key, abs_val);
+    }
+
+    // Ensure loaded node keys are always addressable even if metadata was sparse.
+    for abs in nodes.keys() {
+        out.insert(abs.clone(), abs.clone());
+        let rel = relative_to_root(root, Path::new(abs));
+        out.entry(rel).or_insert_with(|| abs.clone());
+    }
+
+    out
 }
 
 fn current_file_hashes(config: &FoundryConfig) -> Result<BTreeMap<String, String>, String> {
@@ -256,6 +318,8 @@ pub fn upsert_reference_cache_v2_with_report(
     }
 
     let mut touched = 0usize;
+    let mut touched_rel: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut touched_abs: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (abs_path, file_nodes) in &build.nodes {
         let abs = Path::new(abs_path);
         let rel = relative_to_root(&config.root, abs);
@@ -282,12 +346,28 @@ pub fn upsert_reference_cache_v2_with_report(
             if let Some(current) = meta.file_hashes.get(&rel).cloned() {
                 push_hash_history(&mut meta, &rel, &current);
             }
-            meta.node_shards.insert(rel, shard_name);
+            meta.node_shards.insert(rel.clone(), shard_name);
             touched += 1;
         }
 
-        meta.path_to_abs.insert(abs_path.clone(), abs_path.clone());
+        meta.path_to_abs.insert(rel, abs_path.clone());
+        touched_rel.insert(relative_to_root(&config.root, abs));
+        touched_abs.insert(abs_path.clone());
     }
+
+    // Drop stale source-id mappings for touched files before inserting new ones.
+    let old_id_to_path = meta.id_to_path_map.clone();
+    meta.id_to_path_map.retain(|_, p| {
+        !touched_rel.contains(p) && !touched_abs.contains(p)
+    });
+
+    // Drop external refs that originate from touched files (source-id keyed).
+    meta.external_refs.retain(|er| {
+        src_file_id(&er.src)
+            .and_then(|fid| old_id_to_path.get(fid))
+            .map(|p| !touched_rel.contains(p) && !touched_abs.contains(p))
+            .unwrap_or(true)
+    });
 
     for (k, v) in &build.id_to_path_map {
         meta.id_to_path_map.insert(k.clone(), v.clone());
@@ -360,19 +440,35 @@ pub fn save_reference_cache_with_report(
         }
     }
 
+    // Preserve hash history across full saves (do not reset to singleton).
+    let mut file_hash_history: BTreeMap<String, Vec<String>> = fs::read(cache_file_path_v2(&config.root))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<PersistedReferenceCacheV2>(&bytes).ok())
+        .filter(|old| {
+            old.schema_version == CACHE_SCHEMA_VERSION_V2
+                && old.project_root == config.root.to_string_lossy()
+                && old.config_fingerprint == config_fingerprint(config)
+        })
+        .map(|old| old.file_hash_history)
+        .unwrap_or_default();
+    for (rel, hash) in &file_hashes {
+        let history = file_hash_history.entry(rel.clone()).or_default();
+        if history.last().is_none_or(|h| h != hash) {
+            history.push(hash.clone());
+            if history.len() > 8 {
+                let drop_count = history.len() - 8;
+                history.drain(0..drop_count);
+            }
+        }
+    }
+
     let persisted_v2 = PersistedReferenceCacheV2 {
         schema_version: CACHE_SCHEMA_VERSION_V2,
         project_root: config.root.to_string_lossy().to_string(),
         config_fingerprint: config_fingerprint(config),
         file_hashes: file_hashes.clone(),
-        file_hash_history: {
-            let mut h = BTreeMap::new();
-            for (rel, hash) in &file_hashes {
-                h.insert(rel.clone(), vec![hash.clone()]);
-            }
-            h
-        },
-        path_to_abs: build.path_to_abs.clone(),
+        file_hash_history,
+        path_to_abs: normalize_path_to_abs_metadata(&config.root, &build.path_to_abs),
         external_refs: external_refs.clone(),
         id_to_path_map: build.id_to_path_map.clone(),
         node_shards,
@@ -450,22 +546,39 @@ pub fn load_reference_cache_with_report(
             started.elapsed().as_millis(),
         );
     }
-    let current_hashes = match current_file_hashes(config) {
-        Ok(h) => h,
-        Err(e) => {
-            return miss(e, 0, started.elapsed().as_millis());
-        }
-    };
-    let file_count_hashed = current_hashes.len();
 
     let should_try_v2 = matches!(cache_mode, ProjectIndexCacheMode::Auto | ProjectIndexCacheMode::V2);
 
     // Try v2 first (partial warm-start capable).
     let cache_path_v2 = cache_file_path_v2(&config.root);
-    if should_try_v2
-        && let Ok(bytes) = fs::read(&cache_path_v2)
-        && let Ok(persisted) = serde_json::from_slice::<PersistedReferenceCacheV2>(&bytes)
-    {
+    if should_try_v2 {
+        let bytes = match fs::read(&cache_path_v2) {
+            Ok(b) => b,
+            Err(_) => {
+                return miss(
+                    "cache mode v2: no usable v2 cache".to_string(),
+                    0,
+                    started.elapsed().as_millis(),
+                );
+            }
+        };
+        let persisted = match serde_json::from_slice::<PersistedReferenceCacheV2>(&bytes) {
+            Ok(p) => p,
+            Err(_) => {
+                return miss(
+                    "cache mode v2: no usable v2 cache".to_string(),
+                    0,
+                    started.elapsed().as_millis(),
+                );
+            }
+        };
+        let current_hashes = match current_file_hashes(config) {
+            Ok(h) => h,
+            Err(e) => {
+                return miss(e, 0, started.elapsed().as_millis());
+            }
+        };
+        let file_count_hashed = current_hashes.len();
         if persisted.schema_version != CACHE_SCHEMA_VERSION_V2 {
             return miss(
                 format!(
@@ -543,10 +656,12 @@ pub fn load_reference_cache_with_report(
             && file_count_hashed == persisted.file_hashes.len()
             && current_hashes == persisted.file_hashes;
 
+        let path_to_abs_runtime =
+            runtime_path_to_abs_map(&config.root, &persisted.path_to_abs, &nodes);
         return CacheLoadReport {
             build: Some(CachedBuild::from_reference_index(
                 nodes,
-                persisted.path_to_abs,
+                path_to_abs_runtime,
                 external_refs,
                 persisted.id_to_path_map,
                 0,
@@ -566,7 +681,57 @@ pub fn load_reference_cache_with_report(
 
     miss(
         "cache mode v2: no usable v2 cache".to_string(),
-        file_count_hashed,
+        0,
         started.elapsed().as_millis(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_path_to_abs_metadata, runtime_path_to_abs_map};
+    use crate::types::NodeId;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn normalize_path_to_abs_persists_relative_keys() {
+        let root = PathBuf::from("/tmp/proj");
+        let mut input = HashMap::new();
+        input.insert(
+            "/tmp/proj/src/A.sol".to_string(),
+            "/tmp/proj/src/A.sol".to_string(),
+        );
+        input.insert("src/B.sol".to_string(), "/tmp/proj/src/B.sol".to_string());
+
+        let normalized = normalize_path_to_abs_metadata(&root, &input);
+        assert_eq!(
+            normalized.get("src/A.sol"),
+            Some(&"/tmp/proj/src/A.sol".to_string())
+        );
+        assert_eq!(
+            normalized.get("src/B.sol"),
+            Some(&"/tmp/proj/src/B.sol".to_string())
+        );
+        assert!(!normalized.contains_key("/tmp/proj/src/A.sol"));
+    }
+
+    #[test]
+    fn runtime_map_supports_relative_and_absolute_keys() {
+        let root = PathBuf::from("/tmp/proj");
+        let mut persisted = HashMap::new();
+        persisted.insert("src/A.sol".to_string(), "/tmp/proj/src/A.sol".to_string());
+
+        let mut nodes: HashMap<String, HashMap<NodeId, crate::goto::NodeInfo>> = HashMap::new();
+        nodes.insert("/tmp/proj/src/A.sol".to_string(), HashMap::new());
+
+        let runtime = runtime_path_to_abs_map(&root, &persisted, &nodes);
+        assert_eq!(
+            runtime.get("src/A.sol"),
+            Some(&"/tmp/proj/src/A.sol".to_string())
+        );
+        assert_eq!(
+            runtime.get("/tmp/proj/src/A.sol"),
+            Some(&"/tmp/proj/src/A.sol".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- make project-cache reconcile non-blocking for request paths
- avoid accepting/saving zero-source project index results
- add local references fallback plus background full-index retry
- improve project index failure diagnostics when solc returns 0 indexed sources
- persist `path_to_abs` as `relative -> absolute` for v2 metadata and keep runtime compatibility with existing caches
- preserve `file_hash_history` across full saves (append + cap)
- fast-miss v2 cache load path to avoid unnecessary hashing when cache is missing/invalid
- clean stale declaration/source-id mappings during scoped merges/upserts
- simplify logs to plain-language status messages

## Validation
- `cargo build --release`
- targeted cache tests pass (`project_cache::tests`)
- full suite mostly passes; one known fixture issue in `tests/file_operations.rs` depends on current `example/A.sol` content (`contract A` expectation) and is unrelated to this patch.
