### PR TITLE
feat: workspace/executeCommand — solidity.clearCache and solidity.reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Drop v1 cache path; v2 cache is now the only supported mode
 - Auto-create `.gitignore` in the cache directory on first write
+- `workspace/executeCommand` — `solidity.clearCache` deletes the on-disk cache and wipes in-memory AST, forcing a clean rebuild; `solidity.reindex` evicts in-memory AST and triggers a fast background reindex from the warm disk cache
+- Cache fingerprint now includes `lsp_version` so upgrading the server binary automatically invalidates stale caches; optimizer settings (`optimizer`, `optimizer_runs`, `via_ir`) removed from the fingerprint as they do not affect the reference index
 
 ### Fixes
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -12,6 +12,7 @@
 - **Signature Help** — parameter info on function calls, event emits, and mapping access
 - **Inlay Hints** — parameter names and gas estimates
 - **File Operations** — `workspace/willCreateFiles` scaffolding + `workspace/willRenameFiles`/`workspace/willDeleteFiles` import edits + `workspace/didCreateFiles`/`workspace/didRenameFiles`/`workspace/didDeleteFiles` cache migration/re-index (`fileOperations.templateOnCreate`, `fileOperations.updateImportsOnRename`, `fileOperations.updateImportsOnDelete`)
+- **Execute Commands** — `solidity.clearCache` (wipe on-disk cache + in-memory AST, force clean rebuild) · `solidity.reindex` (evict in-memory AST, trigger background reindex from warm disk cache)
 
 See [FEATURES.md](FEATURES.md) for the full LSP feature set and roadmap.
 
@@ -74,7 +75,7 @@ See [FEATURES.md](FEATURES.md) for the full LSP feature set and roadmap.
 - [x] `workspace/didChangeWatchedFiles` - Acknowledges watched file changes (logs only)
 - [x] `workspace/didChangeWorkspaceFolders` - Acknowledges workspace folder changes (logs only)
 - [ ] `workspace/applyEdit` - Inbound handler not implemented (server uses outbound `workspace/applyEdit` to scaffold created files)
-- [ ] `workspace/executeCommand` - Execute workspace commands (stub implementation)
+- [x] `workspace/executeCommand` - Execute workspace commands (`solidity.clearCache`, `solidity.reindex`)
 - [x] `workspace/willCreateFiles` - File creation preview (scaffolding for `.sol`, `.t.sol`, `.s.sol`)
 - [x] `workspace/didCreateFiles` - Post-create scaffold fallback + cache/index refresh
 - [x] `workspace/willRenameFiles` - File rename preview (import path updates)

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -8,6 +8,8 @@
 
 - Drop v1 cache path; v2 cache is now the only supported mode
 - Auto-create `.gitignore` in the cache directory on first write
+- `workspace/executeCommand` — `solidity.clearCache` deletes the on-disk cache and wipes in-memory AST, forcing a clean rebuild; `solidity.reindex` evicts in-memory AST and triggers a fast background reindex from the warm disk cache
+- Cache fingerprint now includes `lsp_version` so upgrading the server binary automatically invalidates stale caches; optimizer settings (`optimizer`, `optimizer_runs`, `via_ir`) removed from the fingerprint as they do not affect the reference index
 
 ### Fixes
 

--- a/docs/pages/reference/caches.md
+++ b/docs/pages/reference/caches.md
@@ -34,7 +34,7 @@ Metadata (`solidity-lsp-schema-v2.json`) includes:
 
 - `schema_version`
 - `project_root`
-- `config_fingerprint`
+- `config_fingerprint` — Keccak256 of `lsp_version`, `solc_version`, `remappings`, `evm_version`, `sources_dir`, `libs`
 - `file_hashes`
 - `file_hash_history`
 - `path_to_abs`
@@ -43,6 +43,22 @@ Metadata (`solidity-lsp-schema-v2.json`) includes:
 - `node_shards`
 
 Each shard file stores one source file’s node entries.
+
+## Cache invalidation
+
+The `config_fingerprint` field is a Keccak256 hash of the inputs that affect the reference index. If any of these change, the entire on-disk cache is treated as a miss and a clean rebuild is triggered automatically:
+
+| Input | Why it matters |
+|---|---|
+| `lsp_version` | Any server upgrade rebuilds from scratch — no stale data from an old binary |
+| `solc_version` | Different compiler → different AST node IDs |
+| `remappings` | Affects which files are resolved and compiled |
+| `evm_version` | Can change which code paths solc parses |
+| `sources_dir` / `libs` | Determines the set of source files in scope |
+
+Optimizer settings (`optimizer`, `optimizer_runs`, `via_ir`) are intentionally excluded — they affect bytecode output but not the AST shape or node IDs that the reference index is built from.
+
+In addition to the fingerprint, each file has an independent Keccak256 content hash. A fingerprint match but content change for individual files triggers a scoped reconcile for those files only, without discarding the whole cache.
 
 ## Freshness model
 
@@ -59,6 +75,54 @@ On successful saves/builds:
 - sync is debounced + single-flight to avoid overlapping work during save bursts.
 
 This keeps reference/goto data fresh without full-project recompiles on every save.
+
+## Commands
+
+The server exposes two `workspace/executeCommand` commands for cache management. Both are advertised during `initialize` so any LSP client can invoke them.
+
+### `solidity.clearCache`
+
+Deletes the entire `.solidity-language-server/` directory on disk and wipes the in-memory AST cache for the current project root. The next file save or open triggers a clean rebuild from scratch. Use this when the cache is corrupt, after a major foundry config change, or when you want to verify a fresh index.
+
+**nvim:**
+```lua
+vim.lsp.buf.execute_command({ command = "solidity.clearCache" })
+```
+
+**VS Code / Cursor** (from the command palette or an extension):
+```ts
+vscode.commands.executeCommand("solidity.clearCache");
+```
+
+**Helix** (`:lsp-execute-command solidity.clearCache` — requires Helix ≥ 24.03 with execute-command support)
+
+Returns `{ "success": true }` on success, or a JSON-RPC `InternalError` if the directory could not be removed.
+
+### `solidity.reindex`
+
+Evicts the in-memory AST cache entry for the current project root and sets the dirty flag so the background cache-sync worker triggers a fresh project index build. The on-disk cache is left intact, so the warm-load on reindex will be fast. Use this when go-to-definition or find-references feels stale but you do not want to throw away the disk cache.
+
+**nvim:**
+```lua
+vim.lsp.buf.execute_command({ command = "solidity.reindex" })
+```
+
+**VS Code / Cursor:**
+```ts
+vscode.commands.executeCommand("solidity.reindex");
+```
+
+Returns `{ "success": true }`.
+
+### Comparison
+
+| | `solidity.clearCache` | `solidity.reindex` |
+|---|---|---|
+| Deletes `.solidity-language-server/` on disk | Yes | No |
+| Clears in-memory AST cache | Yes | Yes |
+| Triggers background reindex | Yes (from scratch) | Yes (warm from disk) |
+| Speed of next index build | Slow (full recompile) | Fast (warm load) |
+| Use when | Cache corrupt / config changed | Index feels stale |
 
 ## Settings that affect cache behavior
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -2135,6 +2135,15 @@ impl LanguageServer for ForgeLsp {
                         ..Default::default()
                     }),
                 }),
+                execute_command_provider: Some(ExecuteCommandOptions {
+                    commands: vec![
+                        "solidity.clearCache".to_string(),
+                        "solidity.reindex".to_string(),
+                    ],
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    },
+                }),
                 ..ServerCapabilities::default()
             },
         })
@@ -2476,6 +2485,94 @@ impl LanguageServer for ForgeLsp {
                     }
                 }
             });
+        }
+    }
+
+    async fn execute_command(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> tower_lsp::jsonrpc::Result<Option<serde_json::Value>> {
+        match params.command.as_str() {
+            // ----------------------------------------------------------------
+            // solidity.clearCache
+            //
+            // Deletes the entire `.solidity-language-server/` directory on disk
+            // and wipes the in-memory AST cache for the current project root.
+            // The next save or file-open will trigger a clean rebuild from
+            // scratch.
+            //
+            // Usage (nvim):
+            //   vim.lsp.buf.execute_command({ command = "solidity.clearCache" })
+            // ----------------------------------------------------------------
+            "solidity.clearCache" => {
+                let root = self.foundry_config.read().await.root.clone();
+                let cache_dir = crate::project_cache::cache_dir(&root);
+
+                let disk_result = if cache_dir.exists() {
+                    std::fs::remove_dir_all(&cache_dir).map_err(|e| format!("{e}"))
+                } else {
+                    Ok(())
+                };
+
+                let root_key = root.to_string_lossy().to_string();
+                self.ast_cache.write().await.remove(&root_key);
+
+                match disk_result {
+                    Ok(()) => {
+                        self.client
+                            .log_message(
+                                MessageType::INFO,
+                                format!(
+                                    "solidity.clearCache: removed {} and cleared in-memory cache",
+                                    cache_dir.display()
+                                ),
+                            )
+                            .await;
+                        Ok(Some(serde_json::json!({ "success": true })))
+                    }
+                    Err(e) => {
+                        self.client
+                            .log_message(
+                                MessageType::ERROR,
+                                format!("solidity.clearCache: failed to remove cache dir: {e}"),
+                            )
+                            .await;
+                        Err(tower_lsp::jsonrpc::Error {
+                            code: tower_lsp::jsonrpc::ErrorCode::InternalError,
+                            message: std::borrow::Cow::Owned(e),
+                            data: None,
+                        })
+                    }
+                }
+            }
+
+            // ----------------------------------------------------------------
+            // solidity.reindex
+            //
+            // Evicts the in-memory AST cache entry for the current project root
+            // and sets the dirty flag so the background cache-sync worker
+            // triggers a fresh project index build. The on-disk cache is left
+            // intact so the warm-load on reindex will be fast.
+            //
+            // Usage (nvim):
+            //   vim.lsp.buf.execute_command({ command = "solidity.reindex" })
+            // ----------------------------------------------------------------
+            "solidity.reindex" => {
+                let root = self.foundry_config.read().await.root.clone();
+                let root_key = root.to_string_lossy().to_string();
+                self.ast_cache.write().await.remove(&root_key);
+                self.project_cache_dirty
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                self.client
+                    .log_message(
+                        MessageType::INFO,
+                        "solidity.reindex: in-memory cache evicted, background reindex triggered",
+                    )
+                    .await;
+                Ok(Some(serde_json::json!({ "success": true })))
+            }
+
+            _ => Err(tower_lsp::jsonrpc::Error::method_not_found()),
         }
     }
 

--- a/src/project_cache.rs
+++ b/src/project_cache.rs
@@ -67,6 +67,12 @@ pub struct CacheSaveReport {
     pub duration_ms: u128,
 }
 
+/// Public helper — returns the root of the on-disk cache directory for
+/// `project_root`. Used by the `solidity.clearCache` command handler.
+pub fn cache_dir(root: &Path) -> PathBuf {
+    root.join(CACHE_DIR)
+}
+
 fn cache_file_path_v2(root: &Path) -> PathBuf {
     root.join(CACHE_DIR).join(CACHE_FILE_V2)
 }
@@ -180,11 +186,11 @@ fn hash_file_list(
 
 fn config_fingerprint(config: &FoundryConfig) -> String {
     let payload = serde_json::json!({
+        // Including the server version means any binary upgrade automatically
+        // invalidates the on-disk cache and triggers a clean rebuild.
+        "lsp_version": env!("CARGO_PKG_VERSION"),
         "solc_version": config.solc_version,
         "remappings": config.remappings,
-        "via_ir": config.via_ir,
-        "optimizer": config.optimizer,
-        "optimizer_runs": config.optimizer_runs,
         "evm_version": config.evm_version,
         "sources_dir": config.sources_dir,
         "libs": config.libs,


### PR DESCRIPTION
Closes #174

## What

Implements `workspace/executeCommand` with two cache management commands:

### `solidity.clearCache`
Deletes the entire `.solidity-language-server/` directory on disk and wipes the in-memory AST cache. Forces a full clean rebuild from scratch on the next save or file open.

### `solidity.reindex`
Evicts the in-memory AST cache entry and sets the dirty flag so the background cache-sync worker triggers a fresh project index build. The on-disk cache is preserved — warm-load makes this fast.

Also:
- **Cache fingerprint includes `lsp_version`** — any binary upgrade now automatically invalidates stale on-disk caches via the fingerprint mismatch path, no schema bump needed
- **Optimizer settings removed from fingerprint** — `optimizer`, `optimizer_runs`, `via_ir` affect bytecode output but not AST shape or the reference index

## Usage

**Neovim:**
```lua
vim.lsp.buf.execute_command({ command = "solidity.clearCache" })
vim.lsp.buf.execute_command({ command = "solidity.reindex" })
```

**VS Code / Cursor:**
```ts
vscode.commands.executeCommand("solidity.clearCache");
vscode.commands.executeCommand("solidity.reindex");
```

## Changes

| File | Change |
|---|---|
| `src/project_cache.rs` | `pub fn cache_dir()` helper |
| `src/lsp.rs` | `execute_command_provider` in capabilities + `execute_command` handler |
| `FEATURES.md` | `workspace/executeCommand` checked, feature bullet added |
| `docs/pages/reference/caches.md` | New Commands section with usage, examples, and comparison table |
| `CHANGELOG.md` / `docs/pages/changelog.md` | v0.1.28 entries |

## Testing

- `cargo build --release` ✅
- `cargo test` — 283 passed, 0 failed ✅
