### PR TITLE
fix: tree-sitter import/assembly string completion guards

### DIFF
--- a/benchmarks/string-completions-no.yaml
+++ b/benchmarks/string-completions-no.yaml
@@ -1,0 +1,36 @@
+# String completion guard — MUST NOT fire cases
+#
+# Verifies that '"' trigger outside import/assembly returns null.
+#
+#   snap 4  revert("    line 8  col 15  trigger '"'  -> NULL
+#   snap 5  string s = " line 12 col 26  trigger '"'  -> NULL
+#
+#   lsp-bench -c benchmarks/string-completions-no.yaml -v
+
+project: example
+file: StringCompletions.sol
+line: 8
+col: 15
+output: benchmarks/string-completions-no
+
+servers:
+  - mmsaki@latest
+
+benchmarks:
+  - textDocument/completion
+
+methods:
+  textDocument/completion:
+    # snap 4 — revert(" trigger '"' at col 15
+    line: 8
+    col: 15
+    trigger: "\""
+    didChange:
+      - file: StringCompletions.revert.snapshot
+        line: 8
+        col: 15
+
+      # snap 5 — string memory s = " trigger '"' at col 26
+      - file: StringCompletions.strvar.snapshot
+        line: 12
+        col: 26

--- a/benchmarks/string-completions.yaml
+++ b/benchmarks/string-completions.yaml
@@ -1,0 +1,43 @@
+# String completion guard — StringCompletions.sol (example/)
+#
+# Five cases across two bench configs:
+#
+#   string-completions.yaml      (this file) — import + assembly (MUST fire)
+#   string-completions-no.yaml                — revert + strvar  (MUST NOT fire)
+#
+# Import cases use no trigger (invoked) because the cursor is mid-string.
+# Assembly uses trigger '"' because the user just typed the opening quote.
+#
+#   lsp-bench -c benchmarks/string-completions.yaml -v
+
+project: example
+file: StringCompletions.sol
+line: 3
+col: 18
+output: benchmarks/string-completions
+
+servers:
+  - mmsaki@latest
+
+benchmarks:
+  - textDocument/completion
+
+methods:
+  textDocument/completion:
+    # snap 1 — import "forge-std/ (bare, cursor mid-string col 18, no trigger)
+    line: 3
+    col: 18
+    didChange:
+      - file: StringCompletions.import-bare.snapshot
+        line: 3
+        col: 18
+
+      # snap 2 — import {} from "forge-std/ (cursor col 26, no trigger)
+      - file: StringCompletions.import-from.snapshot
+        line: 4
+        col: 26
+
+      # snap 3 — assembly (" (cursor inside at col 19, no trigger)
+      - file: StringCompletions.assembly.snapshot
+        line: 17
+        col: 19

--- a/example/StringCompletions.assembly.snapshot
+++ b/example/StringCompletions.assembly.snapshot
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./A.sol";
+import {} from "./B.sol";
+
+contract StringCompletions {
+    function noCompletionRevert() public pure {
+        revert("some error message");
+    }
+
+    function noCompletionAssign() public pure returns (string memory) {
+        string memory s = "hello";
+        return s;
+    }
+
+    function yesCompletionAssembly() internal {
+        assembly ("
+    }
+}

--- a/example/StringCompletions.import-bare.snapshot
+++ b/example/StringCompletions.import-bare.snapshot
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/
+import {} from "./B.sol";
+
+contract StringCompletions {
+    function noCompletionRevert() public pure {
+        revert("some error message");
+    }
+
+    function noCompletionAssign() public pure returns (string memory) {
+        string memory s = "hello";
+        return s;
+    }
+
+    function yesCompletionAssembly() internal {
+        assembly ("memory-safe") {}
+    }
+}

--- a/example/StringCompletions.import-from.snapshot
+++ b/example/StringCompletions.import-from.snapshot
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./A.sol";
+import {} from "forge-std/
+
+contract StringCompletions {
+    function noCompletionRevert() public pure {
+        revert("some error message");
+    }
+
+    function noCompletionAssign() public pure returns (string memory) {
+        string memory s = "hello";
+        return s;
+    }
+
+    function yesCompletionAssembly() internal {
+        assembly ("memory-safe") {}
+    }
+}

--- a/example/StringCompletions.revert.snapshot
+++ b/example/StringCompletions.revert.snapshot
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./A.sol";
+import {} from "./B.sol";
+
+contract StringCompletions {
+    function noCompletionRevert() public pure {
+        revert("
+    }
+
+    function noCompletionAssign() public pure returns (string memory) {
+        string memory s = "hello";
+        return s;
+    }
+
+    function yesCompletionAssembly() internal {
+        assembly ("memory-safe") {}
+    }
+}

--- a/example/StringCompletions.sol
+++ b/example/StringCompletions.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./A.sol";
+import {} from "./B.sol";
+
+contract StringCompletions {
+    function noCompletionRevert() public pure {
+        revert("some error message");
+    }
+
+    function noCompletionAssign() public pure returns (string memory) {
+        string memory s = "hello";
+        return s;
+    }
+
+    function yesCompletionAssembly() internal {
+        assembly ("memory-safe") {}
+    }
+}

--- a/example/StringCompletions.strvar.snapshot
+++ b/example/StringCompletions.strvar.snapshot
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./A.sol";
+import {} from "./B.sol";
+
+contract StringCompletions {
+    function noCompletionRevert() public pure {
+        revert("some error message");
+    }
+
+    function noCompletionAssign() public pure returns (string memory) {
+        string memory s = "
+        return s;
+    }
+
+    function yesCompletionAssembly() internal {
+        assembly ("memory-safe") {}
+    }
+}

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -2047,48 +2047,6 @@ const GLOBAL_FUNCTIONS: &[(&str, &str)] = &[
 // Import path completions
 // ---------------------------------------------------------------------------
 
-/// Returns `true` when `position` is on a line that contains an import
-/// statement (i.e. the line starts with `import` after trimming whitespace).
-/// This is intentionally loose — we just need to know whether to offer
-/// import-path completions at all.
-pub fn cursor_is_on_import_line(source: &str, position: Position) -> bool {
-    source
-        .lines()
-        .nth(position.line as usize)
-        .map(|l| l.trim_start().starts_with("import"))
-        .unwrap_or(false)
-}
-
-/// Returns the text already typed inside the import string on the cursor line,
-/// i.e. everything after the opening `"` or `'` up to `position.character`.
-/// Returns `None` if the cursor is not inside an import string.
-pub fn import_string_prefix(source: &str, position: Position) -> Option<(String, u32)> {
-    let line = source.lines().nth(position.line as usize)?;
-    if !line.trim_start().starts_with("import") {
-        return None;
-    }
-    // Find the last unmatched opening quote before the cursor.
-    let before_cursor = line.get(..position.character as usize)?;
-    let mut quote_char = None;
-    let mut quote_col = None;
-    for (i, ch) in before_cursor.char_indices() {
-        if ch == '"' || ch == '\'' {
-            if quote_char == Some(ch) {
-                // closing quote — we're outside again
-                quote_char = None;
-                quote_col = None;
-            } else if quote_char.is_none() {
-                // opening quote
-                quote_char = Some(ch);
-                quote_col = Some(i as u32 + 1); // col after the quote char
-            }
-        }
-    }
-    let col = quote_col?;
-    let prefix = before_cursor.get(col as usize..)?.to_string();
-    Some((prefix, col))
-}
-
 /// Walk `project_root` recursively and return every `.sol` file as:
 ///   1. A relative path from the current file's directory (e.g. `./libraries/Pool.sol`)
 ///   2. A remapped path for each matching remapping (e.g. `forge-std/Test.sol`)
@@ -2549,89 +2507,6 @@ mod tests {
     }
 
     // --- import path completion tests ---
-
-    #[test]
-    fn cursor_is_on_import_line_detects_import() {
-        let src = "import \"./Foo.sol\";";
-        assert!(super::cursor_is_on_import_line(
-            src,
-            Position {
-                line: 0,
-                character: 10
-            }
-        ));
-    }
-
-    #[test]
-    fn cursor_is_on_import_line_false_for_non_import() {
-        let src = "contract Foo {}";
-        assert!(!super::cursor_is_on_import_line(
-            src,
-            Position {
-                line: 0,
-                character: 5
-            }
-        ));
-    }
-
-    #[test]
-    fn cursor_is_on_import_line_handles_from_style() {
-        let src = "import {Foo} from \"./Foo.sol\";";
-        assert!(super::cursor_is_on_import_line(
-            src,
-            Position {
-                line: 0,
-                character: 20
-            }
-        ));
-    }
-
-    #[test]
-    fn import_string_prefix_mid_path() {
-        // cursor inside import "  ./Fo  |  .sol"
-        let src = "import \"./Foo.sol\";";
-        let (prefix, col) = super::import_string_prefix(
-            src,
-            Position {
-                line: 0,
-                character: 12,
-            },
-        )
-        .expect("should find prefix");
-        assert_eq!(col, 8); // right after the opening `"`
-        assert_eq!(prefix, "./Fo");
-    }
-
-    #[test]
-    fn import_string_prefix_none_outside_quotes() {
-        let src = "import \"./Foo.sol\";";
-        // position 19 is past the closing quote (after the `;`)
-        assert!(
-            super::import_string_prefix(
-                src,
-                Position {
-                    line: 0,
-                    character: 19
-                }
-            )
-            .is_none()
-        );
-    }
-
-    #[test]
-    fn import_string_prefix_none_non_import_line() {
-        let src = "string memory s = \"hello\";";
-        assert!(
-            super::import_string_prefix(
-                src,
-                Position {
-                    line: 0,
-                    character: 20
-                }
-            )
-            .is_none()
-        );
-    }
 
     #[test]
     fn make_import_item_has_filter_text_and_text_edit() {

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,7 +1,7 @@
 use crate::goto::{CachedBuild, bytes_to_pos};
 use crate::types::SourceLoc;
 use crate::utils;
-use tower_lsp::lsp_types::{DocumentLink, Range, Url};
+use tower_lsp::lsp_types::{DocumentLink, Position, Range, Url};
 use tree_sitter::Parser;
 
 /// Extract document links for import directives in the current file.
@@ -140,49 +140,446 @@ pub fn ts_find_imports(source_bytes: &[u8]) -> Vec<TsImport> {
     imports
 }
 
-/// Recursively walk the tree-sitter CST to find `import_directive` nodes.
-fn collect_imports(node: tree_sitter::Node, source_bytes: &[u8], out: &mut Vec<TsImport>) {
-    if node.kind() == "import_directive" {
-        // The `string` child contains the quoted import path.
-        // In tree-sitter-solidity the string node includes the quotes.
+/// Returns the inner LSP [`Range`] of the assembly-flags string the cursor is
+/// inside (e.g. `assembly ("memory-safe")`), or `None` if the cursor is not
+/// inside an assembly flags string.
+///
+/// Works for both complete syntax and unclosed strings that tree-sitter
+/// cannot fully parse (produces an `ERROR` node).
+pub fn ts_cursor_in_assembly_flags(source_bytes: &[u8], position: Position) -> Option<Range> {
+    let source_str = std::str::from_utf8(source_bytes).unwrap_or("");
+    let mut parser = Parser::new();
+    if parser
+        .set_language(&tree_sitter_solidity::LANGUAGE.into())
+        .is_err()
+    {
+        return None;
+    }
+    let tree = parser.parse(source_str, None)?;
+    find_assembly_flags_range(tree.root_node(), source_bytes, source_str, position)
+}
+
+fn find_assembly_flags_range(
+    node: tree_sitter::Node,
+    source_bytes: &[u8],
+    source_str: &str,
+    position: Position,
+) -> Option<Range> {
+    // Fully parsed: assembly_statement > assembly_flags > string
+    if node.kind() == "assembly_flags" {
         for i in 0..node.named_child_count() {
             if let Some(child) = node.named_child(i as u32) {
                 if child.kind() == "string" {
                     let start = child.start_byte();
-                    let end = child.end_byte();
-                    if end > start + 2 && end <= source_bytes.len() {
-                        // Strip quotes: the string node is `"path"` or `'path'`
+                    let end = child.end_byte().min(source_bytes.len());
+                    if end >= start + 2 {
                         let inner_start = start + 1;
                         let inner_end = end - 1;
-                        let path = String::from_utf8_lossy(&source_bytes[inner_start..inner_end])
-                            .to_string();
-
-                        // Convert byte offsets to LSP positions using the
-                        // negotiated encoding (UTF-8 or UTF-16).  Tree-sitter
-                        // columns are byte offsets, which only coincide with
-                        // LSP character units for pure-ASCII lines.
-                        let source_str = std::str::from_utf8(source_bytes).unwrap_or("");
-                        let start_pos = utils::byte_offset_to_position(source_str, inner_start);
-                        let end_pos = utils::byte_offset_to_position(source_str, inner_end);
-
-                        out.push(TsImport {
-                            path,
-                            inner_range: Range {
-                                start: start_pos,
-                                end: end_pos,
-                            },
-                        });
+                        let s = utils::byte_offset_to_position(source_str, inner_start);
+                        let e = utils::byte_offset_to_position(source_str, inner_end);
+                        let r = Range { start: s, end: e };
+                        if position >= r.start && position <= r.end {
+                            return Some(r);
+                        }
                     }
-                    break; // only one path per import
                 }
             }
         }
-        return; // no need to recurse into import_directive children
+    }
+
+    // Incomplete/unclosed: ERROR node containing `assembly` `(` `"` siblings
+    if node.kind() == "ERROR" {
+        let mut saw_assembly = false;
+        let mut saw_lparen = false;
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i as u32) {
+                match child.kind() {
+                    "assembly" => {
+                        saw_assembly = true;
+                    }
+                    "(" if saw_assembly => {
+                        saw_lparen = true;
+                    }
+                    "\"" | "'" if saw_assembly && saw_lparen => {
+                        let q = source_bytes[child.start_byte()];
+                        let inner_start = child.start_byte() + 1;
+                        let inner_end = find_closing_quote(source_bytes, inner_start, q);
+                        let s = utils::byte_offset_to_position(source_str, inner_start);
+                        let e = utils::byte_offset_to_position(source_str, inner_end);
+                        let r = Range { start: s, end: e };
+                        if position >= r.start && position <= r.end {
+                            return Some(r);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i as u32) {
+            if let Some(r) = find_assembly_flags_range(child, source_bytes, source_str, position) {
+                return Some(r);
+            }
+        }
+    }
+    None
+}
+
+/// Returns the inner LSP [`Range`] of the import string the cursor is inside,
+/// or `None` if the cursor is not inside an import string.
+///
+/// "Inside" means `inner_range.start <= position <= inner_range.end` (the
+/// range does **not** include the surrounding quotes).
+pub fn ts_cursor_in_import_string(source_bytes: &[u8], position: Position) -> Option<Range> {
+    ts_find_imports(source_bytes)
+        .into_iter()
+        .find(|imp| {
+            let r = &imp.inner_range;
+            position >= r.start && position <= r.end
+        })
+        .map(|imp| imp.inner_range)
+}
+
+/// Recursively walk the tree-sitter CST to find `import_directive` nodes, plus
+/// `ERROR` nodes that begin with the `import` keyword (handles unclosed strings
+/// such as `import {} from "` which tree-sitter cannot fully parse).
+fn collect_imports(node: tree_sitter::Node, source_bytes: &[u8], out: &mut Vec<TsImport>) {
+    let source_str = std::str::from_utf8(source_bytes).unwrap_or("");
+
+    if node.kind() == "import_directive" {
+        // Walk all children (not just named) to find either:
+        //   a) a `string` node — the complete import path
+        //   b) an `ERROR` child containing a bare `"` — an unclosed/malformed
+        //      import string that tree-sitter couldn't fully parse (e.g.
+        //      `import "forge-std/` followed by more lines greedy-consumed into
+        //      the same import_directive)
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i as u32) {
+                if child.kind() == "string" {
+                    push_string_node(child, source_bytes, source_str, out);
+                    return;
+                }
+                if child.kind() == "ERROR" {
+                    // Look for a bare opening quote inside the ERROR node
+                    for j in 0..child.child_count() {
+                        if let Some(gc) = child.child(j as u32) {
+                            if gc.kind() == "\"" || gc.kind() == "'" {
+                                let q = source_bytes[gc.start_byte()];
+                                let inner_start = gc.start_byte() + 1;
+                                let inner_end = find_closing_quote(source_bytes, inner_start, q);
+                                let path =
+                                    String::from_utf8_lossy(&source_bytes[inner_start..inner_end])
+                                        .to_string();
+                                let start_pos =
+                                    utils::byte_offset_to_position(source_str, inner_start);
+                                let end_pos = utils::byte_offset_to_position(source_str, inner_end);
+                                out.push(TsImport {
+                                    path,
+                                    inner_range: Range {
+                                        start: start_pos,
+                                        end: end_pos,
+                                    },
+                                });
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    // Handle ERROR nodes that start with `import` — this is what tree-sitter
+    // produces for incomplete/unclosed import strings like:
+    //   import {} from "
+    //   import {} from "whi
+    // In this case the source is unparseable so there is no `import_directive`;
+    // instead we get an ERROR node whose first token is the `import` keyword.
+    // We look for a bare `"` or `'` child token and treat everything from that
+    // quote to end-of-source as the (open-ended) inner range.
+    if node.kind() == "ERROR" {
+        let mut has_import = false;
+        let mut quote_byte: Option<usize> = None;
+        let mut quote_ch: Option<u8> = None;
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i as u32) {
+                let kind = child.kind();
+                if kind == "import" {
+                    has_import = true;
+                }
+                if has_import && (kind == "\"" || kind == "'") {
+                    // bare opening quote with no matching close
+                    let q = source_bytes[child.start_byte()];
+                    quote_byte = Some(child.start_byte() + 1); // byte after the quote
+                    quote_ch = Some(q);
+                    break;
+                }
+                // Also handle a complete `string` node inside the ERROR
+                if has_import && kind == "string" {
+                    push_string_node(child, source_bytes, source_str, out);
+                    quote_byte = None; // handled
+                    break;
+                }
+            }
+        }
+        if let (Some(inner_start), Some(q)) = (quote_byte, quote_ch) {
+            // Find the end: either the matching closing quote or end-of-line.
+            let inner_end = find_closing_quote(source_bytes, inner_start, q);
+            let path = String::from_utf8_lossy(&source_bytes[inner_start..inner_end]).to_string();
+            let start_pos = utils::byte_offset_to_position(source_str, inner_start);
+            let end_pos = utils::byte_offset_to_position(source_str, inner_end);
+            out.push(TsImport {
+                path,
+                inner_range: Range {
+                    start: start_pos,
+                    end: end_pos,
+                },
+            });
+        }
+        return;
     }
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
             collect_imports(child, source_bytes, out);
         }
+    }
+}
+
+/// Push a `TsImport` for a tree-sitter `string` node (which includes its quotes).
+/// Handles both complete (`"path"`) and malformed/unclosed strings where
+/// tree-sitter may have consumed content past a newline.
+///
+/// The inner range is always clamped to the current line so that a greedy
+/// parse of an unclosed string doesn't bleed into the next line.
+fn push_string_node(
+    node: tree_sitter::Node,
+    source_bytes: &[u8],
+    source_str: &str,
+    out: &mut Vec<TsImport>,
+) {
+    let start = node.start_byte();
+    let raw_end = node.end_byte().min(source_bytes.len());
+    if raw_end < start + 1 {
+        return;
+    }
+    let inner_start = start + 1;
+    // Clamp end to end-of-line so a greedy unclosed string doesn't bleed
+    // across newlines. Also strip the closing quote if present.
+    let eol = find_closing_quote(source_bytes, inner_start, b'\n');
+    let closing_quote = source_bytes
+        .get(inner_start..eol)
+        .and_then(|s| s.iter().position(|&b| b == source_bytes[start]))
+        .map(|p| inner_start + p);
+    let inner_end = closing_quote.unwrap_or(eol);
+
+    let path = String::from_utf8_lossy(&source_bytes[inner_start..inner_end]).to_string();
+    let start_pos = utils::byte_offset_to_position(source_str, inner_start);
+    let end_pos = utils::byte_offset_to_position(source_str, inner_end);
+    out.push(TsImport {
+        path,
+        inner_range: Range {
+            start: start_pos,
+            end: end_pos,
+        },
+    });
+}
+
+/// Find the byte offset of the closing `quote_char` starting at `from`, or
+/// return the end of the current line (or end-of-source) if none is found.
+fn find_closing_quote(source_bytes: &[u8], from: usize, quote_char: u8) -> usize {
+    for i in from..source_bytes.len() {
+        let b = source_bytes[i];
+        if b == quote_char {
+            return i;
+        }
+        // Stop at newline — an import string can't span lines.
+        if b == b'\n' || b == b'\r' {
+            return i;
+        }
+    }
+    source_bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pos(line: u32, character: u32) -> Position {
+        Position { line, character }
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_inside() {
+        // Cursor at col 12 is between the quotes of `"./Foo.sol"`
+        let src = b"import \"./Foo.sol\";";
+        let range = ts_cursor_in_import_string(src, pos(0, 12));
+        assert!(range.is_some(), "expected Some inside import string");
+        let r = range.unwrap();
+        // inner_range should start right after the opening quote (col 8)
+        assert_eq!(r.start.character, 8);
+        // and end right before the closing quote (col 17)
+        assert_eq!(r.end.character, 17);
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_outside_semicolon() {
+        // Cursor past the closing quote
+        let src = b"import \"./Foo.sol\";";
+        let range = ts_cursor_in_import_string(src, pos(0, 19));
+        assert!(range.is_none(), "should be None past closing quote");
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_non_import_literal() {
+        // A regular string literal should NOT match
+        let src = b"string memory s = \"hello\";";
+        let range = ts_cursor_in_import_string(src, pos(0, 20));
+        assert!(range.is_none(), "should be None for non-import string");
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_from_style() {
+        // Named import: `import {Foo} from "./Foo.sol";`
+        let src = b"import {Foo} from \"./Foo.sol\";";
+        // col 19 is just after the opening `"`
+        let range = ts_cursor_in_import_string(src, pos(0, 19));
+        assert!(range.is_some(), "expected Some for from-style import");
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_empty_string() {
+        // `import ""` — cursor right after the opening quote (col 8)
+        let src = b"import \"\"";
+        let range = ts_cursor_in_import_string(src, pos(0, 8));
+        assert!(range.is_some(), "expected Some for empty import string");
+        let r = range.unwrap();
+        assert_eq!(r.start.character, 8);
+        assert_eq!(r.end.character, 8); // inner range is zero-width
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_unclosed() {
+        // `import {} from "` — unclosed, cursor right after the quote (col 16)
+        let src = b"import {} from \"";
+        let range = ts_cursor_in_import_string(src, pos(0, 16));
+        assert!(range.is_some(), "expected Some for unclosed import string");
+        let r = range.unwrap();
+        assert_eq!(r.start.character, 16); // byte after the `"`
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_unclosed_mid() {
+        // `import {} from "whi` — cursor at col 19
+        let src = b"import {} from \"whi";
+        let range = ts_cursor_in_import_string(src, pos(0, 19));
+        assert!(range.is_some(), "expected Some mid unclosed import string");
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_non_import_unclosed() {
+        // `string memory s = "hello` — unclosed non-import string should NOT match
+        let src = b"string memory s = \"hello";
+        let range = ts_cursor_in_import_string(src, pos(0, 20));
+        assert!(
+            range.is_none(),
+            "should be None for unclosed non-import string"
+        );
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_bare_unclosed() {
+        // `import "` — bare import with no from, unclosed
+        let src = b"import \"";
+        let range = ts_cursor_in_import_string(src, pos(0, 8));
+        assert!(range.is_some(), "expected Some for bare unclosed import");
+        let r = range.unwrap();
+        assert_eq!(r.start.character, 8);
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_bare_unclosed_mid() {
+        // `import "forge-std/` — mid-path unclosed
+        let src = b"import \"forge-std/";
+        // cursor at end (col 18)
+        let range = ts_cursor_in_import_string(src, pos(0, 18));
+        assert!(
+            range.is_some(),
+            "expected Some for `import \"forge-std/` (unclosed mid-path)"
+        );
+        let r = range.unwrap();
+        assert_eq!(r.start.character, 8); // after opening quote
+        assert_eq!(r.end.character, 18); // end of source
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_assembly_flags() {
+        // `assembly ("memory-safe") {}` must NOT trigger import completions.
+        let src = b"contract A { function f() internal { assembly (\"memory-safe\") {} } }";
+        let range = ts_cursor_in_import_string(src, pos(0, 50));
+        assert!(
+            range.is_none(),
+            "assembly dialect string must not trigger import completions"
+        );
+    }
+
+    #[test]
+    fn ts_cursor_in_import_string_revert_string() {
+        // `revert("some error")` — string_literal inside a call, not an import.
+        let src = b"contract A { function f() public { revert(\"err\"); } }";
+        let range = ts_cursor_in_import_string(src, pos(0, 43));
+        assert!(
+            range.is_none(),
+            "revert string must not trigger import completions"
+        );
+    }
+
+    // --- assembly_flags tests ---
+
+    #[test]
+    fn ts_cursor_in_assembly_flags_complete() {
+        // `assembly ("memory-safe") {}` — cursor inside the string
+        let src = b"contract A { function f() internal { assembly (\"memory-safe\") {} } }";
+        let range = ts_cursor_in_assembly_flags(src, pos(0, 50));
+        assert!(
+            range.is_some(),
+            "expected Some inside assembly flags string"
+        );
+    }
+
+    #[test]
+    fn ts_cursor_in_assembly_flags_unclosed() {
+        // `assembly ("` — unclosed, cursor right after the quote
+        let src = b"contract A { function f() internal { assembly (\"";
+        let range = ts_cursor_in_assembly_flags(src, pos(0, 48));
+        assert!(
+            range.is_some(),
+            "expected Some for unclosed assembly flags string"
+        );
+    }
+
+    #[test]
+    fn ts_cursor_in_assembly_flags_not_import() {
+        // Must not match a plain import string
+        let src = b"import \"./Foo.sol\";";
+        let range = ts_cursor_in_assembly_flags(src, pos(0, 12));
+        assert!(
+            range.is_none(),
+            "import string must not match assembly_flags"
+        );
+    }
+
+    #[test]
+    fn ts_cursor_in_assembly_flags_not_revert() {
+        // Must not match a revert string
+        let src = b"contract A { function f() public { revert(\"err\"); } }";
+        let range = ts_cursor_in_assembly_flags(src, pos(0, 43));
+        assert!(
+            range.is_none(),
+            "revert string must not match assembly_flags"
+        );
     }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -3193,22 +3193,78 @@ impl LanguageServer for ForgeLsp {
             .and_then(|p| p.to_str().map(|s| s.to_string()));
 
         // --- Import path completions ---
-        // If the cursor is on an import line, return all .sol paths in the
-        // project relative to the current file. The editor's fuzzy filter
-        // narrows the list — no partial-path or trigger-char edge cases needed.
-        let is_import_trigger = matches!(trigger_char, Some("\"") | Some("'") | Some("/"));
-        let on_import_line = completion::cursor_is_on_import_line(&source_text, position);
+        // Use tree-sitter to determine whether the cursor is inside an import
+        // string.  This is exact: it finds `import_directive > string` nodes
+        // and checks if the cursor falls within the inner range (excluding
+        // quotes).  This avoids false positives for arbitrary string literals
+        // like `string memory s = "l`.
+        //
+        // For `"` / `'` trigger chars the LSP trigger position is the column
+        // of the quote character itself; the inside of the string starts one
+        // character to the right.
+        let check_pos = if matches!(trigger_char, Some("\"") | Some("'")) {
+            Position {
+                line: position.line,
+                character: position.character.saturating_add(1),
+            }
+        } else {
+            position
+        };
 
-        if is_import_trigger || on_import_line {
+        // --- Assembly dialect completions ---
+        // `assembly ("memory-safe") {}` — the only valid Solidity assembly
+        // dialect is "memory-safe".  Fire exactly one completion item when
+        // the cursor is inside the assembly_flags string.
+        if let Some(asm_range) =
+            links::ts_cursor_in_assembly_flags(source_text.as_bytes(), check_pos)
+        {
+            let text_edit = CompletionTextEdit::Edit(TextEdit {
+                range: Range {
+                    start: Position {
+                        line: position.line,
+                        character: asm_range.start.character,
+                    },
+                    end: Position {
+                        line: position.line,
+                        character: check_pos.character,
+                    },
+                },
+                new_text: "memory-safe".to_string(),
+            });
+            let item = CompletionItem {
+                label: "memory-safe".to_string(),
+                kind: Some(CompletionItemKind::VALUE),
+                detail: Some("Solidity assembly dialect".to_string()),
+                filter_text: Some("memory-safe".to_string()),
+                text_edit: Some(text_edit),
+                ..Default::default()
+            };
+            return Ok(Some(CompletionResponse::List(CompletionList {
+                is_incomplete: false,
+                items: vec![item],
+            })));
+        }
+
+        // --- Import path completions ---
+        // Use tree-sitter to determine whether the cursor is inside an import
+        // string.  This is exact: it finds `import_directive > string` nodes
+        // and checks if the cursor falls within the inner range (excluding
+        // quotes).  This avoids false positives for arbitrary string literals
+        // like `string memory s = "l`.
+        if let Some(import_range) =
+            links::ts_cursor_in_import_string(source_text.as_bytes(), check_pos)
+        {
             if let Ok(current_file) = uri.to_file_path() {
                 let foundry_cfg = self.foundry_config.read().await.clone();
                 let project_root = foundry_cfg.root.clone();
                 let remappings = crate::solc::resolve_remappings(&foundry_cfg).await;
-                // Extract the text already typed inside the import string so
-                // we can build a text_edit that replaces it, and set filter_text
-                // so clients filter on the full path label.
-                let typed_range = completion::import_string_prefix(&source_text, position)
-                    .map(|(_prefix, start_col)| (position.line, start_col, position.character));
+                // Replace only the already-typed portion of the path so the
+                // client inserts cleanly (no duplication).
+                let typed_range = Some((
+                    position.line,
+                    import_range.start.character,
+                    check_pos.character,
+                ));
                 let items = completion::all_sol_import_paths(
                     &current_file,
                     &project_root,
@@ -3220,6 +3276,13 @@ impl LanguageServer for ForgeLsp {
                     items,
                 })));
             }
+            return Ok(None);
+        }
+
+        // A `"` or `'` trigger that is not inside an import string or assembly
+        // flags string should never produce completions — return null so the
+        // client does not show a spurious popup.
+        if matches!(trigger_char, Some("\"") | Some("'")) {
             return Ok(None);
         }
 


### PR DESCRIPTION
## Summary

- Replace heuristic quote-counting (`import_string_prefix`, `cursor_is_on_import_line`) with exact tree-sitter detection for when the cursor is inside an import string
- Add `ts_cursor_in_import_string()` — handles `import "..."`, `import {} from "..."`, bare unclosed (`import "forge-std/`), and from-style unclosed
- Add `ts_cursor_in_assembly_flags()` — detects cursor inside `assembly("memory-safe")`, returns exactly one `"memory-safe"` completion item
- Return `null` for any `"` / `'` trigger outside import/assembly contexts — `revert("`, `string s = "`, etc. no longer produce spurious completions
- Fix `collect_imports` to walk `import_directive > ERROR > "` for greedy-parsed unclosed bare imports

## Bench results (`lsp-bench`)

| Case | Expected | Result |
|---|---|---|
| `import "forge-std/` | import paths | ✅ 5 items |
| `import {} from "forge-std/` | import paths | ✅ 5 items |
| `assembly ("` | `memory-safe` only | ✅ 1 item |
| `revert("` | null | ✅ null |
| `string memory s = "` | null | ✅ null |

## Test fixtures added

- `example/StringCompletions.sol` — small contract covering all 5 string contexts
- `benchmarks/string-completions.yaml` — must-fire cases
- `benchmarks/string-completions-no.yaml` — must-not-fire cases
