### PR TITLE
feat: qualifier-aware references, goto, and rename for qualified type paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@
 ### Features
 
 - Project-wide `PathInterner` for canonical file IDs — solc assigns file IDs sequentially based on input order, causing cross-compilation reference bugs; the interner assigns deterministic IDs so all builds share the same ID space (#185)
-- `textDocument/hover` — show AST node ID (`NodeId: \`<id>\``) in hover tooltips for debugging; references show `NodeId: \`<id>\` referencedDeclaration: \`<decl_id>\``
+- `textDocument/hover` — show AST node ID (`NodeId: \`<id>\``) in hover tooltips for debugging; references show ``NodeId: \`<id>\` referencedDeclaration: \`<decl_id>\` ``
+- `textDocument/references` — qualifier-aware reference resolution; "Find All References" on a container (contract/library/interface) now includes qualified type paths where the container appears as a prefix (e.g., `Pool` in `Pool.State`) (#187)
+- `textDocument/definition` — qualifier segment goto; clicking the qualifier in a qualified type path (e.g., `Pool` in `Pool.State`) navigates to the container declaration instead of the struct/enum (#187)
+- `CachedBuild` gains `qualifier_refs` field (`HashMap<NodeId, Vec<NodeId>>`) — maps container declaration IDs to `IdentifierPath` node IDs used as qualifiers; built at cache time by `build_qualifier_refs()` and merged across builds via `merge_missing_from()` (#187)
+- `NodeInfo` gains `scope` field — the containing declaration's node ID from the AST `scope` property; used to resolve qualified type path containers (#187)
+- `dedup_locations()` removes both exact and contained-range duplicates from reference results, preventing qualified type paths from producing duplicate entries (#187)
 
 ### Fixes
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,8 +1,8 @@
 ## Features
 
-- **Go to Definition** / **Go to Declaration** — jump to any symbol across files
-- **Find References** — all usages of a symbol across the project
-- **Rename** — project-wide symbol rename with prepare support
+- **Go to Definition** / **Go to Declaration** — jump to any symbol across files, including qualifier segments in qualified type paths (e.g., `Pool` in `Pool.State` navigates to the contract/library)
+- **Find References** — all usages of a symbol across the project, including qualified type path references (e.g., `Pool` in `Pool.State`)
+- **Rename** — project-wide symbol rename with prepare support, including qualifier usages in qualified type paths
 - **Hover** — signatures, NatSpec docs, function/error/event selectors, `@inheritdoc` resolution, AST node ID for debugging
 - **Completions** — scope-aware with two modes (fast cache vs full recomputation)
 - **Document Links** — clickable imports, type names, function calls

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -8,6 +8,11 @@
 
 - Project-wide `PathInterner` for canonical file IDs — solc assigns file IDs sequentially based on input order, causing cross-compilation reference bugs; the interner assigns deterministic IDs so all builds share the same ID space (#185)
 - `textDocument/hover` — show AST node ID (``NodeId: `<id>` ``) in hover tooltips for debugging; references show ``NodeId: `<id>` referencedDeclaration: `<decl_id>` ``
+- `textDocument/references` — qualifier-aware reference resolution; "Find All References" on a container (contract/library/interface) now includes qualified type paths where the container appears as a prefix (e.g., `Pool` in `Pool.State`) (#187)
+- `textDocument/definition` — qualifier segment goto; clicking the qualifier in a qualified type path (e.g., `Pool` in `Pool.State`) navigates to the container declaration instead of the struct/enum (#187)
+- `CachedBuild` gains `qualifier_refs` field (`HashMap<NodeId, Vec<NodeId>>`) — maps container declaration IDs to `IdentifierPath` node IDs used as qualifiers; built at cache time by `build_qualifier_refs()` and merged across builds via `merge_missing_from()` (#187)
+- `NodeInfo` gains `scope` field — the containing declaration's node ID from the AST `scope` property; used to resolve qualified type path containers (#187)
+- `dedup_locations()` removes both exact and contained-range duplicates from reference results, preventing qualified type paths from producing duplicate entries (#187)
 
 ### Fixes
 

--- a/docs/pages/docs/features.md
+++ b/docs/pages/docs/features.md
@@ -1,4 +1,24 @@
-## LSP Methods
+## Features
+
+- **Go to Definition** / **Go to Declaration** — jump to any symbol across files, including qualifier segments in qualified type paths (e.g., `Pool` in `Pool.State` navigates to the contract/library)
+- **Find References** — all usages of a symbol across the project, including qualified type path references (e.g., `Pool` in `Pool.State`)
+- **Rename** — project-wide symbol rename with prepare support, including qualifier usages in qualified type paths
+- **Hover** — signatures, NatSpec docs, function/error/event selectors, `@inheritdoc` resolution, AST node ID for debugging
+- **Completions** — scope-aware with two modes (fast cache vs full recomputation)
+- **Document Links** — clickable imports, type names, function calls
+- **Document Symbols** / **Workspace Symbols** — outline and search
+- **Formatting** — via `forge fmt`
+- **Diagnostics** — from `solc` and `forge lint`
+- **Signature Help** — parameter info on function calls, event emits, and mapping access
+- **Inlay Hints** — parameter names and gas estimates
+- **File Operations** — `workspace/willCreateFiles` scaffolding + `workspace/willRenameFiles`/`workspace/willDeleteFiles` import edits + `workspace/didCreateFiles`/`workspace/didRenameFiles`/`workspace/didDeleteFiles` cache migration/re-index (`fileOperations.templateOnCreate`, `fileOperations.updateImportsOnRename`, `fileOperations.updateImportsOnDelete`)
+- **Code Actions** — `textDocument/codeAction` quickfix engine; handles `unused-import` forge-lint diagnostic with "Remove unused import" action; JSON-driven rule table in `data/error_codes.json`
+- **Execute Commands** — `solidity.clearCache` (wipe on-disk cache + in-memory AST, force clean rebuild) · `solidity.reindex` (evict in-memory AST, trigger background reindex from warm disk cache)
+- **Save Performance** — content hash check skips redundant solc rebuilds when file is unchanged; `collect_import_pragmas` runs on blocking thread pool to avoid stalling the async runtime on large projects
+
+See [FEATURES.md](FEATURES.md) for the full LSP feature set and roadmap.
+
+### LSP Methods
 
 **General**
 

--- a/docs/pages/reference/caches.md
+++ b/docs/pages/reference/caches.md
@@ -83,6 +83,7 @@ Caches the list of solc versions installed by svm-rs. Populated lazily on first 
 | `completion_cache` | `Arc<CompletionCache>` | `completion::build_completion_cache()` | Full completion index (see below). Wrapped in `Arc` so it can be shared into `ForgeLsp.completion_cache` without cloning. |
 | `build_version` | `i32` | Set from LSP document version | The `didChange`/`didOpen` version that produced this build. Used to detect dirty files (`text_version > build_version`). |
 | `content_hash` | `u64` | `DefaultHasher` on source text | Hash of the source text at compile time. Compared in `on_change()` to skip rebuilds when content is identical (format-on-save guard). `0` for project-index builds. |
+| `qualifier_refs` | `HashMap<NodeId, Vec<NodeId>>` | `build_qualifier_refs()` in `goto.rs` | Maps container declaration ID (contract/library/interface) to `IdentifierPath` node IDs that use it as a qualifier prefix in qualified type paths (e.g., `Pool` in `Pool.State`). Used by references and rename to include qualifier usages. |
 
 ### `NodeInfo` stored per-node
 
@@ -93,10 +94,11 @@ Caches the list of solc versions installed by svm-rs. Populated lazily on first 
 - `node_type` — e.g. `"FunctionDefinition"`
 - `member_location` — for `MemberAccess` expressions
 - `absolute_path` — for `ImportDirective` nodes
+- `scope` — optional `NodeId`; the AST `scope` field pointing to the containing declaration (contract, library, interface, function). Used by `build_qualifier_refs()` to resolve the container in qualified type paths like `Pool.State`.
 
 ### Warm-loaded cache limitation
 
-When a `CachedBuild` is reconstructed from the on-disk v2 cache via `from_reference_index()`, only `nodes`, `path_to_abs`, `external_refs`, and `id_to_path_map` are populated. `decl_index`, `gas_index`, `hint_index`, `doc_index`, and `completion_cache` are all empty.
+When a `CachedBuild` is reconstructed from the on-disk v2 cache via `from_reference_index()`, only `nodes`, `path_to_abs`, `external_refs`, `id_to_path_map`, and `qualifier_refs` are populated. `decl_index`, `gas_index`, `hint_index`, `doc_index`, and `completion_cache` are all empty.
 
 This means after a warm-load, only cross-file goto-definition and references work immediately. Hover docs, parameter inlay hints, gas estimates, and completions are not available until the first full `solc_project_index()` run completes. This is logged at startup and is by design: the warm-load prioritizes low latency for navigation features.
 
@@ -321,7 +323,8 @@ See the setup schema in [Setup Overview](/setup).
 
 | File | Role |
 |---|---|
-| `src/goto.rs` | `CachedBuild`, `NodeInfo`, `cache_ids()`, `from_reference_index()`, `remap_src_canonical()`, `canonicalize_node_info()` |
+| `src/goto.rs` | `CachedBuild`, `NodeInfo`, `cache_ids()`, `from_reference_index()`, `remap_src_canonical()`, `canonicalize_node_info()`, `build_qualifier_refs()`, `resolve_qualifier_goto()`, `find_node_info()` |
+| `src/references.rs` | `dedup_locations()`, `resolve_qualifier_target()`, `collect_qualifier_references()`, `goto_references_for_target()`, `resolve_target_location()` |
 | `src/project_cache.rs` | All on-disk v2 persistence: save, load, upsert, shard logic |
 | `src/lsp.rs` | Owns all in-memory caches; drives lifecycle via LSP events; both async workers |
 | `src/completion.rs` | `CompletionCache`, `build_completion_cache()` |

--- a/docs/pages/reference/goto.md
+++ b/docs/pages/reference/goto.md
@@ -89,6 +89,18 @@ A separate race was fixed so goto/hover read correct text after formatting:
 - **Parameter and local declaration navigation** is supported by tree-sitter declaration scanning.
 - **Content hash guard:** `on_change` skips a rebuild entirely when the saved text hash matches `CachedBuild.content_hash` from the last successful build. This prevents stale `build_version` drift in format-on-save loops.
 
+## Qualifier goto
+
+When the cursor is on the qualifier segment of a qualified type path (e.g., `Pool` in `Pool.State`), `resolve_qualifier_goto()` intercepts before the normal `goto_bytes()` path and navigates to the container declaration (the contract/library/interface).
+
+**How it works:**
+- Detects the cursor is on a multi-segment `IdentifierPath`'s first `nameLocations` entry.
+- Follows `referencedDeclaration` to the declaration node (e.g., the struct).
+- Reads the declaration's `scope` field to find the container's node ID.
+- Emits a `Location` pointing to the container's `name_location`.
+
+**Helper:** `find_node_info()` is a reusable utility that looks up a `NodeInfo` by `NodeId` across all files in the nodes map.
+
 ## Reused Infrastructure
 
 | Component | From | Used For |

--- a/docs/pages/reference/references.md
+++ b/docs/pages/reference/references.md
@@ -21,7 +21,7 @@ If you are looking for import-string navigation (for example `import "./Pool.sol
 - `id_to_path_map: HashMap<SolcFileId, String>`
 - `external_refs: HashMap<SrcLocation, NodeId>`
 
-`NodeInfo` includes fields like `src`, `name_location`, and `referenced_declaration`.
+`NodeInfo` includes fields like `src`, `name_location`, `referenced_declaration`, and `scope`.
 
 At request time, the server uses this snapshot to resolve references quickly, then merges results from other cached builds to get cross-file coverage.
 
@@ -51,7 +51,7 @@ In `src/lsp.rs`, the `references` handler does the following:
 - Collect current-build references.
 - Derive stable target location `(def_abs_path, def_byte_offset)`.
 - Scan other cached builds for cross-file references to the same target.
-- Deduplicate by `(uri, start, end)` and return.
+- Deduplicate via `dedup_locations()` — removes exact `(uri, start, end)` duplicates and contained-range duplicates (when one range strictly contains another on the same URI, keep only the narrower range). This prevents qualified type paths like `IPoolManager.ModifyLiquidityParams` from producing two entries per usage site.
 
 This is why you get both local and cross-file references in one response when caches are available.
 
@@ -59,6 +59,7 @@ This is why you get both local and cross-file references in one response when ca
 
 Inside `references.rs`, resolution follows this order:
 
+- Check for qualifier cursor: if the cursor is on the first segment of a multi-segment `IdentifierPath` (e.g., `Pool` in `Pool.State`), `resolve_qualifier_target()` resolves the container via `referencedDeclaration → scope` and dispatches to `collect_qualifier_references()`.
 - Try Yul resolution first (`externalReferences` mapping).
 - Fall back to AST span match (smallest containing node).
 - Normalize to declaration target: follow `referencedDeclaration` when present, else use the node id directly.
@@ -75,6 +76,24 @@ During references:
 - Yul usage locations are also appended back into the result set by matching `decl_id`.
 
 This is why references work inside inline assembly rather than only in high-level Solidity syntax.
+
+## Qualifier references
+
+When the cursor is on the qualifier segment of a qualified type path (e.g., `Pool` in `Pool.State`), the server resolves references for the container (contract/library/interface) rather than the struct/enum member.
+
+**Detection:** `resolve_qualifier_target()` checks that the node is an `IdentifierPath` with `name_locations.len() > 1` and that the cursor falls within `name_locations[0]` (the first segment).
+
+**Resolution chain:** The function follows `referencedDeclaration` (which points to the struct/enum) to find that declaration node, then reads its `scope` field to get the container's node ID.
+
+**Collection:** `collect_qualifier_references()` merges two sources:
+- Direct references to the container (imports, expression-position usages) via the normal `all_references` index.
+- Qualifier references from the `qualifier_refs` index — `IdentifierPath` nodes where the container appears as the first segment. These are emitted using `nameLocations[0]` to produce the correct narrow range.
+
+**Index:** `CachedBuild.qualifier_refs` (`HashMap<NodeId, Vec<NodeId>>`) is built at cache time by `build_qualifier_refs()`. It scans all multi-segment `IdentifierPath` nodes, follows `referencedDeclaration → scope`, and maps the container ID to the `IdentifierPath` node ID.
+
+**Cross-file:** `goto_references_for_target()` also checks the `qualifier_refs` index when the target is a container, so cross-file scans (used by both the references handler and the rename handler) include qualifier usages from other builds.
+
+**Merge:** `merge_missing_from()` merges `qualifier_refs` entries from other builds so the combined index is complete.
 
 ## Canonical file IDs via PathInterner
 

--- a/src/goto.rs
+++ b/src/goto.rs
@@ -18,6 +18,12 @@ pub struct NodeInfo {
     pub node_type: Option<String>,
     pub member_location: Option<String>,
     pub absolute_path: Option<String>,
+    /// The AST `scope` field — the node ID of the containing declaration
+    /// (contract, library, interface, function, etc.). Used to resolve the
+    /// qualifier in qualified type paths like `Pool.State` where `scope`
+    /// on the `State` struct points to the `Pool` library.
+    #[serde(default)]
+    pub scope: Option<NodeId>,
 }
 
 /// All AST child keys to traverse (Solidity + Yul).
@@ -125,6 +131,14 @@ pub struct CachedBuild {
     /// Used to skip redundant rebuilds when content has not changed
     /// (e.g. format-on-save loops that re-trigger didSave with identical text).
     pub content_hash: u64,
+    /// Qualifier reference index: maps a container declaration ID
+    /// (contract/library/interface) to `IdentifierPath` node IDs that use
+    /// it as a qualifier prefix in qualified type paths (e.g., `Pool.State`).
+    ///
+    /// Built at cache time by following `referencedDeclaration` on multi-segment
+    /// `IdentifierPath` nodes to their declaration, then reading the declaration's
+    /// `scope` field to find the container.
+    pub qualifier_refs: HashMap<NodeId, Vec<NodeId>>,
 }
 
 impl CachedBuild {
@@ -245,6 +259,12 @@ impl CachedBuild {
             std::sync::Arc::new(cc)
         };
 
+        // Build the qualifier reference index: for each multi-segment
+        // IdentifierPath (e.g., `Pool.State`), follow referencedDeclaration
+        // to the declaration node, then read its `scope` to find the
+        // container (contract/library/interface). Map container_id → [node_id].
+        let qualifier_refs = build_qualifier_refs(&nodes);
+
         // The raw AST JSON is fully consumed — all data has been extracted
         // into the pre-built indexes above. `ast` is dropped here.
 
@@ -261,6 +281,7 @@ impl CachedBuild {
             completion_cache,
             build_version,
             content_hash: 0,
+            qualifier_refs,
         }
     }
 
@@ -288,6 +309,16 @@ impl CachedBuild {
             self.id_to_path_map
                 .entry(k.clone())
                 .or_insert_with(|| v.clone());
+        }
+        // Merge qualifier_refs: for each container, add any qualifier node
+        // IDs from `other` that aren't already present in `self`.
+        for (container_id, other_qrefs) in &other.qualifier_refs {
+            let entry = self.qualifier_refs.entry(*container_id).or_default();
+            for &qnode_id in other_qrefs {
+                if !entry.contains(&qnode_id) {
+                    entry.push(qnode_id);
+                }
+            }
         }
     }
 
@@ -321,6 +352,9 @@ impl CachedBuild {
             None,
         ));
 
+        // Build qualifier refs from the warm-loaded nodes.
+        let qualifier_refs = build_qualifier_refs(&nodes);
+
         Self {
             nodes,
             path_to_abs,
@@ -334,8 +368,51 @@ impl CachedBuild {
             completion_cache,
             build_version,
             content_hash: 0,
+            qualifier_refs,
         }
     }
+}
+
+/// Build the qualifier reference index from the cached node maps.
+///
+/// For each `IdentifierPath` node with `nameLocations.len() > 1` (i.e., a
+/// qualified path like `Pool.State`), follows `referencedDeclaration` to the
+/// declaration node, reads its `scope` field (the containing contract /
+/// library / interface), and records `scope_id → [identifierpath_node_id]`.
+///
+/// This allows "Find All References" on a container to include qualified
+/// type references where the container appears as a prefix.
+fn build_qualifier_refs(
+    nodes: &HashMap<AbsPath, HashMap<NodeId, NodeInfo>>,
+) -> HashMap<NodeId, Vec<NodeId>> {
+    // First pass: collect all nodes' scope fields into a lookup table.
+    // We need this to look up the scope of a referencedDeclaration target.
+    let mut node_scope: HashMap<NodeId, NodeId> = HashMap::new();
+    for file_nodes in nodes.values() {
+        for (id, info) in file_nodes {
+            if let Some(scope_id) = info.scope {
+                node_scope.insert(*id, scope_id);
+            }
+        }
+    }
+
+    // Second pass: for each multi-segment IdentifierPath, resolve the
+    // container via referencedDeclaration → scope.
+    let mut qualifier_refs: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+    for file_nodes in nodes.values() {
+        for (id, info) in file_nodes {
+            if info.name_locations.len() > 1 && info.node_type.as_deref() == Some("IdentifierPath")
+            {
+                if let Some(ref_decl) = info.referenced_declaration
+                    && let Some(&scope_id) = node_scope.get(&ref_decl)
+                {
+                    qualifier_refs.entry(scope_id).or_default().push(*id);
+                }
+            }
+        }
+    }
+
+    qualifier_refs
 }
 
 /// Return type of [`cache_ids`]: `(nodes, path_to_abs, external_refs)`.
@@ -434,6 +511,7 @@ pub fn cache_ids(sources: &Value) -> CachedIds {
                                 .get("absolutePath")
                                 .and_then(|v| v.as_str())
                                 .map(|s| s.to_string()),
+                            scope: ast.get("scope").and_then(|v| v.as_i64()).map(NodeId),
                         },
                     );
                 }
@@ -509,6 +587,7 @@ pub fn cache_ids(sources: &Value) -> CachedIds {
                                 .get("absolutePath")
                                 .and_then(|v| v.as_str())
                                 .map(|s| s.to_string()),
+                            scope: tree.get("scope").and_then(|v| v.as_i64()).map(NodeId),
                         };
 
                         nodes.get_mut(&abs_path).unwrap().insert(id, node_info);
@@ -705,6 +784,85 @@ pub fn goto_bytes(
     Some((file_path, loc.offset, loc.length))
 }
 
+/// Check if cursor is on the qualifier segment (first `nameLocations` entry)
+/// of a multi-segment `IdentifierPath` (e.g., `Pool` in `Pool.State`).
+/// If so, resolve the container declaration via `referencedDeclaration → scope`
+/// and return a Location pointing to the container's name.
+fn resolve_qualifier_goto(
+    build: &CachedBuild,
+    file_uri: &Url,
+    byte_position: usize,
+) -> Option<Location> {
+    let path = file_uri.to_file_path().ok()?;
+    let path_str = path.to_str()?;
+    let abs_path = build.path_to_abs.get(path_str)?;
+    let file_nodes = build.nodes.get(abs_path)?;
+
+    // Find the IdentifierPath node under the cursor.
+    let node_id = crate::references::byte_to_id(&build.nodes, abs_path, byte_position)?;
+    let node_info = file_nodes.get(&node_id)?;
+
+    // Must be a multi-segment IdentifierPath.
+    if node_info.node_type.as_deref() != Some("IdentifierPath")
+        || node_info.name_locations.len() <= 1
+    {
+        return None;
+    }
+
+    // Check if cursor is on the first segment (the qualifier).
+    let first_loc = SourceLoc::parse(&node_info.name_locations[0])?;
+    if byte_position < first_loc.offset || byte_position >= first_loc.end() {
+        return None;
+    }
+
+    // Follow referencedDeclaration to the declaration node, then read scope.
+    let ref_decl_id = node_info.referenced_declaration?;
+    // Find the declaration node to get its scope.
+    let decl_node = find_node_info(&build.nodes, ref_decl_id)?;
+    let scope_id = decl_node.scope?;
+
+    // Resolve the container declaration's location.
+    let container_node = find_node_info(&build.nodes, scope_id)?;
+    let loc_str = container_node
+        .name_location
+        .as_deref()
+        .unwrap_or(container_node.src.as_str());
+    let loc = SourceLoc::parse(loc_str)?;
+    let file_path = build.id_to_path_map.get(&loc.file_id_str())?;
+
+    let absolute_path = if std::path::Path::new(file_path).is_absolute() {
+        std::path::PathBuf::from(file_path)
+    } else {
+        std::env::current_dir().ok()?.join(file_path)
+    };
+
+    let target_bytes = std::fs::read(&absolute_path).ok()?;
+    let start_pos = bytes_to_pos(&target_bytes, loc.offset)?;
+    let end_pos = bytes_to_pos(&target_bytes, loc.end())?;
+    let target_uri = Url::from_file_path(&absolute_path).ok()?;
+
+    Some(Location {
+        uri: target_uri,
+        range: Range {
+            start: start_pos,
+            end: end_pos,
+        },
+    })
+}
+
+/// Find a `NodeInfo` by node ID across all files.
+fn find_node_info<'a>(
+    nodes: &'a HashMap<AbsPath, HashMap<NodeId, NodeInfo>>,
+    node_id: NodeId,
+) -> Option<&'a NodeInfo> {
+    for file_nodes in nodes.values() {
+        if let Some(node) = file_nodes.get(&node_id) {
+            return Some(node);
+        }
+    }
+    None
+}
+
 /// Go-to-declaration using pre-built `CachedBuild` indices.
 /// Avoids redundant O(N) AST traversal by reusing cached node maps.
 pub fn goto_declaration_cached(
@@ -714,6 +872,14 @@ pub fn goto_declaration_cached(
     source_bytes: &[u8],
 ) -> Option<Location> {
     let byte_position = pos_to_bytes(source_bytes, position);
+
+    // Check if cursor is on the qualifier segment of a multi-segment
+    // IdentifierPath (e.g., cursor on `Pool` in `Pool.State`).
+    // If so, navigate to the container declaration (via scope) instead
+    // of the struct/enum that referencedDeclaration points to.
+    if let Some(location) = resolve_qualifier_goto(build, file_uri, byte_position) {
+        return Some(location);
+    }
 
     if let Some((file_path, location_bytes, length)) = goto_bytes(
         &build.nodes,

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -3948,17 +3948,10 @@ impl LanguageServer for ForgeLsp {
             }
         }
 
-        // Deduplicate across all caches
-        let mut seen = std::collections::HashSet::new();
-        locations.retain(|loc| {
-            seen.insert((
-                loc.uri.clone(),
-                loc.range.start.line,
-                loc.range.start.character,
-                loc.range.end.line,
-                loc.range.end.character,
-            ))
-        });
+        // Deduplicate across all caches — removes exact duplicates and
+        // contained-range duplicates (e.g., UserDefinedTypeName full-span
+        // vs IdentifierPath name-only span for qualified type paths).
+        locations = references::dedup_locations(locations);
 
         if locations.is_empty() {
             self.client

--- a/src/references.rs
+++ b/src/references.rs
@@ -6,6 +6,85 @@ use crate::goto::{
 };
 use crate::types::{AbsPath, NodeId, SourceLoc};
 
+/// Deduplicate locations: remove exact duplicates and contained-range
+/// duplicates. When two locations share the same URI and one range contains
+/// the other (e.g., `IPoolManager.ModifyLiquidityParams` col 9-43 and
+/// `ModifyLiquidityParams` col 22-43), keep only the narrower range.
+/// This prevents qualified type paths from producing two result entries
+/// per usage site.
+pub fn dedup_locations(locations: Vec<Location>) -> Vec<Location> {
+    if locations.len() <= 1 {
+        return locations;
+    }
+
+    // First pass: exact dedup by (uri, start, end).
+    let mut unique_locations = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for location in locations {
+        let key = (
+            location.uri.clone(),
+            location.range.start.line,
+            location.range.start.character,
+            location.range.end.line,
+            location.range.end.character,
+        );
+        if seen.insert(key) {
+            unique_locations.push(location);
+        }
+    }
+
+    // Second pass: remove locations whose range contains another location's
+    // range on the same URI (keep the narrower one).
+    // For each location, check if any other location on the same URI has a
+    // range strictly contained within it. If so, the wider location is
+    // a `UserDefinedTypeName` full-span duplicate of the narrower
+    // `IdentifierPath` name location.
+    let mut to_remove = vec![false; unique_locations.len()];
+    for i in 0..unique_locations.len() {
+        if to_remove[i] {
+            continue;
+        }
+        for j in (i + 1)..unique_locations.len() {
+            if to_remove[j] {
+                continue;
+            }
+            if unique_locations[i].uri != unique_locations[j].uri {
+                continue;
+            }
+            let ri = unique_locations[i].range;
+            let rj = unique_locations[j].range;
+            // Check if ri contains rj (ri is wider)
+            if range_contains(ri, rj) {
+                to_remove[i] = true;
+            }
+            // Check if rj contains ri (rj is wider)
+            if range_contains(rj, ri) {
+                to_remove[j] = true;
+            }
+        }
+    }
+
+    unique_locations
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| !to_remove[*i])
+        .map(|(_, loc)| loc)
+        .collect()
+}
+
+/// Check if range `outer` strictly contains range `inner`.
+/// Both ranges must be non-equal and `inner` must be fully within `outer`.
+fn range_contains(outer: Range, inner: Range) -> bool {
+    if outer == inner {
+        return false;
+    }
+    let outer_start = (outer.start.line, outer.start.character);
+    let outer_end = (outer.end.line, outer.end.character);
+    let inner_start = (inner.start.line, inner.start.character);
+    let inner_end = (inner.end.line, inner.end.character);
+    outer_start <= inner_start && inner_end <= outer_end
+}
+
 pub fn all_references(
     nodes: &HashMap<AbsPath, HashMap<NodeId, NodeInfo>>,
 ) -> HashMap<NodeId, Vec<NodeId>> {
@@ -165,6 +244,20 @@ pub fn goto_references_cached(
     };
     let byte_position = pos_to_bytes(source_bytes, position);
 
+    // Check if cursor is on the qualifier segment of a multi-segment
+    // IdentifierPath (e.g., `Pool` in `Pool.State`). If so, resolve
+    // references for the container (via referencedDeclaration → scope)
+    // instead of the struct.
+    if let Some(qualifier_target) = resolve_qualifier_target(&build.nodes, abs_path, byte_position)
+    {
+        return collect_qualifier_references(
+            build,
+            qualifier_target,
+            include_declaration,
+            &all_refs,
+        );
+    }
+
     // Check if cursor is on a Yul external reference first
     let target_node_id = if let Some(decl_id) = byte_to_decl_via_external_refs(
         &build.external_refs,
@@ -214,21 +307,101 @@ pub fn goto_references_cached(
         }
     }
 
-    let mut unique_locations = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for location in locations {
-        let key = (
-            location.uri.clone(),
-            location.range.start.line,
-            location.range.start.character,
-            location.range.end.line,
-            location.range.end.character,
-        );
-        if seen.insert(key) {
-            unique_locations.push(location);
+    dedup_locations(locations)
+}
+
+/// Check if cursor is on the qualifier segment (first `nameLocations` entry) of
+/// a multi-segment `IdentifierPath`. Returns the container declaration's node ID
+/// (via `referencedDeclaration → scope`) if so.
+fn resolve_qualifier_target(
+    nodes: &HashMap<AbsPath, HashMap<NodeId, NodeInfo>>,
+    abs_path: &str,
+    byte_position: usize,
+) -> Option<NodeId> {
+    let node_id = byte_to_id(nodes, abs_path, byte_position)?;
+    let file_nodes = nodes.get(abs_path)?;
+    let node_info = file_nodes.get(&node_id)?;
+
+    // Must be a multi-segment IdentifierPath
+    if node_info.node_type.as_deref() != Some("IdentifierPath")
+        || node_info.name_locations.len() <= 1
+    {
+        return None;
+    }
+
+    // Check cursor is on the first segment (the qualifier)
+    let first_loc = SourceLoc::parse(&node_info.name_locations[0])?;
+    if byte_position < first_loc.offset || byte_position >= first_loc.end() {
+        return None;
+    }
+
+    // Follow referencedDeclaration → declaration node → scope
+    let ref_decl_id = node_info.referenced_declaration?;
+    // Find the declaration node across all files to read its scope
+    for file_nodes in nodes.values() {
+        if let Some(decl_node) = file_nodes.get(&ref_decl_id) {
+            return decl_node.scope;
         }
     }
-    unique_locations
+    None
+}
+
+/// Collect references for a container declaration (contract/library/interface),
+/// including both direct references and qualifier references from the
+/// `qualifier_refs` index.
+fn collect_qualifier_references(
+    build: &CachedBuild,
+    container_id: NodeId,
+    include_declaration: bool,
+    all_refs: &HashMap<NodeId, Vec<NodeId>>,
+) -> Vec<Location> {
+    let mut results: HashSet<NodeId> = HashSet::new();
+    if include_declaration {
+        results.insert(container_id);
+    }
+
+    // Direct references to the container (imports, expression-position usages)
+    if let Some(refs) = all_refs.get(&container_id) {
+        results.extend(refs.iter().copied());
+    }
+
+    let mut locations = Vec::new();
+
+    // Emit locations for direct references (using name_location as usual)
+    for id in &results {
+        if let Some(location) =
+            id_to_location_with_index(&build.nodes, &build.id_to_path_map, *id, None)
+        {
+            locations.push(location);
+        }
+    }
+
+    // Emit qualifier locations from the qualifier_refs index.
+    // These are IdentifierPath nodes where the container appears as the
+    // first segment (e.g., `Pool` in `Pool.State`). Emit nameLocations[0].
+    if let Some(qualifier_node_ids) = build.qualifier_refs.get(&container_id) {
+        for &qnode_id in qualifier_node_ids {
+            if let Some(location) = id_to_location_with_index(
+                &build.nodes,
+                &build.id_to_path_map,
+                qnode_id,
+                Some(0), // first segment = qualifier
+            ) {
+                locations.push(location);
+            }
+        }
+    }
+
+    // Also add Yul external reference use sites for the container
+    for (src_str, decl_id) in &build.external_refs {
+        if *decl_id == container_id
+            && let Some(location) = src_to_location(src_str.as_str(), &build.id_to_path_map)
+        {
+            locations.push(location);
+        }
+    }
+
+    dedup_locations(locations)
 }
 
 /// Resolve cursor position to the target definition's location (abs_path + byte offset).
@@ -245,6 +418,23 @@ pub fn resolve_target_location(
     let path_str = path.to_str()?;
     let abs_path = build.path_to_abs.get(path_str)?;
     let byte_position = pos_to_bytes(source_bytes, position);
+
+    // Check if cursor is on the qualifier segment of a qualified path.
+    // If so, resolve the target to the container declaration instead.
+    if let Some(container_id) = resolve_qualifier_target(&build.nodes, abs_path, byte_position) {
+        for (file_abs_path, file_nodes) in &build.nodes {
+            if let Some(node_info) = file_nodes.get(&container_id) {
+                let loc_str = node_info
+                    .name_location
+                    .as_deref()
+                    .unwrap_or(node_info.src.as_str());
+                if let Some(src_loc) = SourceLoc::parse(loc_str) {
+                    return Some((file_abs_path.to_string(), src_loc.offset));
+                }
+            }
+        }
+        return None;
+    }
 
     // Check Yul external references first
     let target_node_id = if let Some(decl_id) = byte_to_decl_via_external_refs(
@@ -320,6 +510,14 @@ pub fn goto_references_for_target(
         None => return vec![],
     };
 
+    // Check if the target is a container (contract/library/interface) that
+    // has qualifier references. When the caller resolved a qualifier cursor
+    // (e.g., `Pool` in `Pool.State`), the def_byte_offset points to the
+    // container declaration. If this build has qualifier_refs for that
+    // container, we need to include them.
+    let is_qualifier_target =
+        !build.qualifier_refs.is_empty() && build.qualifier_refs.contains_key(&target_node_id);
+
     // Build a set of node IDs that live in the excluded file so we can
     // skip them cheaply during the id_to_location loop.
     let excluded_ids: HashSet<NodeId> = if let Some(excl) = exclude_abs_path {
@@ -357,6 +555,27 @@ pub fn goto_references_for_target(
         }
     }
 
+    // Emit qualifier locations from the qualifier_refs index when the
+    // target is a container. These are IdentifierPath nodes where the
+    // container appears as the first segment (e.g., `Pool` in `Pool.State`).
+    if is_qualifier_target {
+        if let Some(qualifier_node_ids) = build.qualifier_refs.get(&target_node_id) {
+            for &qnode_id in qualifier_node_ids {
+                if excluded_ids.contains(&qnode_id) {
+                    continue;
+                }
+                if let Some(location) = id_to_location_with_index(
+                    &build.nodes,
+                    &build.id_to_path_map,
+                    qnode_id,
+                    Some(0), // first segment = qualifier
+                ) {
+                    locations.push(location);
+                }
+            }
+        }
+    }
+
     // Yul external reference use sites
     for (src_str, decl_id) in &build.external_refs {
         if *decl_id == target_node_id {
@@ -376,5 +595,5 @@ pub fn goto_references_for_target(
         }
     }
 
-    locations
+    dedup_locations(locations)
 }


### PR DESCRIPTION
## Summary

Resolves #187 — deduplicate references for qualified type paths, add go-to-definition on qualifier segments, and include qualifier usages in Find All References and Rename.

- **Dedup references**: `dedup_locations()` removes both exact duplicates and contained-range duplicates, preventing `IPoolManager.ModifyLiquidityParams` from producing two entries per usage site
- **Qualifier goto**: clicking `Pool` in `Pool.State` navigates to the `Pool` contract/library declaration via `resolve_qualifier_goto()` (follows `referencedDeclaration → scope`)
- **Qualifier references**: Find All References on a qualifier segment returns all direct refs to the container plus qualifier appearances in qualified type paths via the `qualifier_refs` index
- **Cross-file support**: `goto_references_for_target()` includes qualifier refs from other builds; `merge_missing_from()` merges the `qualifier_refs` index
- **Rename**: works for qualifier segments across files with no changes to `rename.rs` — it flows through the fixed `goto_references_for_target()`

## Implementation

| Component | File | Purpose |
|---|---|---|
| `scope` field on `NodeInfo` | `src/goto.rs` | AST `scope` property — points to containing declaration |
| `qualifier_refs` on `CachedBuild` | `src/goto.rs` | `HashMap<NodeId, Vec<NodeId>>` — container → qualifier IdentifierPath nodes |
| `build_qualifier_refs()` | `src/goto.rs` | Builds the index at cache time |
| `resolve_qualifier_goto()` | `src/goto.rs` | Intercepts goto for qualifier cursor |
| `find_node_info()` | `src/goto.rs` | Reusable helper to find NodeInfo by NodeId across all files |
| `dedup_locations()` | `src/references.rs` | Exact + contained-range dedup |
| `resolve_qualifier_target()` | `src/references.rs` | Detects qualifier cursor, returns container NodeId |
| `collect_qualifier_references()` | `src/references.rs` | Merges direct refs + qualifier_refs for a container |
| `goto_references_for_target()` | `src/references.rs` | Cross-file scan now includes qualifier refs |
| `merge_missing_from()` | `src/goto.rs` | Merges qualifier_refs across builds |

## Tests

- `cargo build --release` — clean
- `cargo test --release` — 318 unit + 132 integration tests pass, 0 failures

## Docs

Updated per Documentation Sync Rule:
- `docs/pages/reference/caches.md` — `qualifier_refs` field, `scope` on NodeInfo, warm-load, implementation files
- `docs/pages/reference/references.md` — qualifier references section, dedup description, target resolution flow
- `docs/pages/reference/goto.md` — qualifier goto section
- `CHANGELOG.md` + `docs/pages/changelog.md` — 5 new feature entries
- `FEATURES.md` + `docs/pages/docs/features.md` — synced and updated