### PR TITLE
detect low-level .call/.staticcall/.delegatecall in outgoing call hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Low-level call hierarchy edges — `callHierarchy/outgoingCalls` now surfaces `.call()`, `.staticcall()`, and `.delegatecall()` as synthetic call edges, covering both Solidity `MemberAccess` nodes (which have no `referencedDeclaration`) and Yul call opcodes (which have no AST `id`); selection ranges point at the `.call` / opcode site (#211)
 - Alias-aware navigation — `textDocument/definition`, `textDocument/declaration`, `textDocument/implementation`, `textDocument/references`, and `textDocument/rename` all work correctly through import aliases (e.g. `import {Foo as Bar}`) (#197)
 - Goto-implementation fallback — when no implementations are found for a function, falls back to goto-definition instead of returning nothing (#200)
 - Live buffer compilation — `textDocument/didChange` compiles the editor buffer directly, providing cross-file diagnostics for unsaved edits

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -57,7 +57,7 @@ See [FEATURES.md](FEATURES.md) for the full LSP feature set and roadmap.
 - [x] `textDocument/signatureHelp` - Function signature help (functions, events, mappings)
 - [x] `textDocument/prepareCallHierarchy` - Prepare call hierarchy (resolve callable at cursor)
 - [x] `callHierarchy/incomingCalls` - Find all callers of a function/modifier/contract
-- [x] `callHierarchy/outgoingCalls` - Find all callees from a function/modifier/contract
+- [x] `callHierarchy/outgoingCalls` - Find all callees from a function/modifier/contract (includes low-level `.call()`/`.staticcall()`/`.delegatecall()` and Yul call opcodes)
 - [ ] `textDocument/typeDefinition` - Go to type definition
 - [x] `textDocument/implementation` - Go to implementation (interface → concrete implementations via baseFunctions)
 - [x] `textDocument/documentHighlight` - Document highlighting (read/write classification)

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Low-level call hierarchy edges — `callHierarchy/outgoingCalls` now surfaces `.call()`, `.staticcall()`, and `.delegatecall()` as synthetic call edges, covering both Solidity `MemberAccess` nodes (which have no `referencedDeclaration`) and Yul call opcodes (which have no AST `id`); selection ranges point at the `.call` / opcode site (#211)
 - Alias-aware navigation — `textDocument/definition`, `textDocument/declaration`, `textDocument/implementation`, `textDocument/references`, and `textDocument/rename` all work correctly through import aliases (e.g. `import {Foo as Bar}`) (#197)
 - Goto-implementation fallback — when no implementations are found for a function, falls back to goto-definition instead of returning nothing (#200)
 - Live buffer compilation — `textDocument/didChange` compiles the editor buffer directly, providing cross-file diagnostics for unsaved edits

--- a/docs/pages/docs/features.md
+++ b/docs/pages/docs/features.md
@@ -34,7 +34,7 @@
 - [x] `textDocument/signatureHelp` - Function signature help (functions, events, mappings)
 - [x] `textDocument/prepareCallHierarchy` - Prepare call hierarchy (resolve callable at cursor)
 - [x] `callHierarchy/incomingCalls` - Find all callers of a function/modifier/contract
-- [x] `callHierarchy/outgoingCalls` - Find all callees from a function/modifier/contract
+- [x] `callHierarchy/outgoingCalls` - Find all callees from a function/modifier/contract (includes low-level `.call()`/`.staticcall()`/`.delegatecall()` and Yul call opcodes)
 - [ ] `textDocument/typeDefinition` - Go to type definition
 - [x] `textDocument/implementation` - Go to implementation (interface → concrete implementations via baseFunctions)
 - [x] `textDocument/documentHighlight` - Document highlighting (read/write classification)

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -22,11 +22,27 @@
 //! When `base_function_implementation` is populated, incoming calls expand
 //! the target to include all equivalent IDs (interface ↔ implementation),
 //! so callers via interface-typed references are included.
+//!
+//! # Low-level calls
+//!
+//! Solidity's `.call()`, `.staticcall()`, and `.delegatecall()` have no
+//! `referencedDeclaration` in the AST because they are built-in address
+//! methods. These are detected separately:
+//!
+//! - **Solidity `MemberAccess`**: Nodes with `member_name ∈ {call, staticcall,
+//!   delegatecall}` and `referenced_declaration: None`. These have `id` fields
+//!   and are in the `nodes` index.
+//! - **Yul opcodes**: `YulFunctionCall` nodes with `functionName.name ∈ {call,
+//!   staticcall, delegatecall}`. These have NO `id` field and are stored in
+//!   `CachedBuild::low_level_calls`.
+//!
+//! Low-level calls produce synthetic `CallHierarchyItem`s with no backing
+//! declaration node.
 
 use std::collections::HashMap;
 use tower_lsp::lsp_types::{CallHierarchyItem, Range, SymbolKind, Url};
 
-use crate::goto::{CachedBuild, NodeInfo, bytes_to_pos};
+use crate::goto::{CachedBuild, LOW_LEVEL_CALL_NAMES, NodeInfo, bytes_to_pos};
 use crate::references::byte_to_id;
 use crate::solc_ast::DeclNode;
 use crate::types::{AbsPath, NodeId, SolcFileId, SourceLoc};
@@ -309,6 +325,155 @@ pub fn outgoing_calls(
     results.sort_by(|a, b| a.0.0.cmp(&b.0.0).then_with(|| a.1.cmp(&b.1)));
     results.dedup();
     results
+}
+
+/// Find outgoing low-level calls from a given caller function/modifier.
+///
+/// Detects two patterns:
+/// 1. **Solidity `MemberAccess`**: nodes in the `nodes` index with
+///    `member_name ∈ {call, staticcall, delegatecall}` and no
+///    `referenced_declaration`, inside the caller's span.
+/// 2. **Yul opcodes**: entries in `low_level_calls` whose `src` falls
+///    inside the caller's span.  Only actual call opcodes are included
+///    (not `mstore`, `sload`, etc.) — scoped by `YUL_CALL_OPCODES` at
+///    index time.
+///
+/// Returns `(CallHierarchyItem, call_range)` pairs.  The
+/// `CallHierarchyItem` is synthetic — there is no backing declaration
+/// node, so it carries no `nodeId` in `data`.
+pub fn outgoing_low_level_calls(
+    build: &CachedBuild,
+    caller_id: NodeId,
+) -> Vec<(CallHierarchyItem, Range)> {
+    let caller_info = match find_node_info(&build.nodes, caller_id) {
+        Some(info) => info,
+        None => return vec![],
+    };
+    let caller_src = match SourceLoc::parse(caller_info.src.as_str()) {
+        Some(s) => s,
+        None => return vec![],
+    };
+
+    let mut results: Vec<(CallHierarchyItem, Range)> = Vec::new();
+
+    // ── Pass 1: Solidity MemberAccess low-level calls ──────────────────
+    for (_abs_path, file_nodes) in &build.nodes {
+        for (_ref_id, ref_info) in file_nodes {
+            // Only MemberAccess nodes with no referenced_declaration.
+            if ref_info.referenced_declaration.is_some() {
+                continue;
+            }
+            let Some(mn) = ref_info.member_name.as_deref() else {
+                continue;
+            };
+            if !LOW_LEVEL_CALL_NAMES.contains(&mn) {
+                continue;
+            }
+            let Some(ref_src) = SourceLoc::parse(ref_info.src.as_str()) else {
+                continue;
+            };
+            if ref_src.file_id != caller_src.file_id {
+                continue;
+            }
+            if !(caller_src.offset <= ref_src.offset && ref_src.end() <= caller_src.end()) {
+                continue;
+            }
+
+            // Build a synthetic CallHierarchyItem for this low-level call.
+            // Use member_location (the `.call` identifier) for selection_range
+            // so the cursor lands on the call site, not the whole expression.
+            let name_src = ref_info
+                .member_location
+                .as_deref()
+                .unwrap_or(ref_info.src.as_str());
+            if let Some((item, call_range)) = low_level_call_item_from_src(
+                mn,
+                ref_info.src.as_str(),
+                name_src,
+                &build.id_to_path_map,
+            ) {
+                results.push((item, call_range));
+            }
+        }
+    }
+
+    // ── Pass 2: Yul call opcodes ───────────────────────────────────────
+    for llc in &build.low_level_calls {
+        let Some(llc_src) = SourceLoc::parse(llc.src.as_str()) else {
+            continue;
+        };
+        if llc_src.file_id != caller_src.file_id {
+            continue;
+        }
+        if !(caller_src.offset <= llc_src.offset && llc_src.end() <= caller_src.end()) {
+            continue;
+        }
+
+        // Use functionName.src for selection_range (just the opcode name).
+        if let Some((item, call_range)) = low_level_call_item_from_src(
+            &llc.kind,
+            llc.src.as_str(),
+            llc.name_src.as_str(),
+            &build.id_to_path_map,
+        ) {
+            results.push((item, call_range));
+        }
+    }
+
+    results
+}
+
+/// Build a synthetic `CallHierarchyItem` and call-site `Range` for a
+/// low-level call from its kind (`"call"`, `"staticcall"`, `"delegatecall"`).
+///
+/// - `src` is the full expression span (used for `range` and `fromRanges`).
+/// - `name_src` is the identifier-only span (used for `selection_range` so
+///   the cursor lands on the `.call` / `call` site).
+fn low_level_call_item_from_src(
+    kind: &str,
+    src: &str,
+    name_src: &str,
+    id_to_path_map: &HashMap<SolcFileId, String>,
+) -> Option<(CallHierarchyItem, Range)> {
+    let loc = SourceLoc::parse(src)?;
+    let file_path_str = id_to_path_map.get(&loc.file_id_str())?;
+
+    let file_path = if std::path::Path::new(file_path_str).is_absolute() {
+        std::path::PathBuf::from(file_path_str)
+    } else {
+        std::env::current_dir().ok()?.join(file_path_str)
+    };
+
+    let source_bytes = std::fs::read(&file_path).ok()?;
+    let uri = Url::from_file_path(&file_path).ok()?;
+
+    let start = bytes_to_pos(&source_bytes, loc.offset)?;
+    let end = bytes_to_pos(&source_bytes, loc.end())?;
+    let range = Range { start, end };
+
+    // Parse the name_src for the selection range (the .call / call site).
+    let selection_range = SourceLoc::parse(name_src)
+        .and_then(|nl| {
+            let ns = bytes_to_pos(&source_bytes, nl.offset)?;
+            let ne = bytes_to_pos(&source_bytes, nl.end())?;
+            Some(Range { start: ns, end: ne })
+        })
+        .unwrap_or(range);
+
+    let name = format!(".{}()", kind);
+
+    let item = CallHierarchyItem {
+        name,
+        kind: SymbolKind::FUNCTION,
+        tags: None,
+        detail: Some(format!("low-level {}", kind)),
+        uri,
+        range,
+        selection_range,
+        data: Some(serde_json::json!({ "lowLevelCall": kind })),
+    };
+
+    Some((item, selection_range))
 }
 
 // ── LSP conversion helpers ─────────────────────────────────────────────────

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -460,7 +460,13 @@ fn low_level_call_item_from_src(
         })
         .unwrap_or(range);
 
-    let name = format!(".{}()", kind);
+    // Read the actual source text at the full expression span for the name.
+    // e.g. "user.call("")" or "delegatecall(0, 0, 0, 0, 0, 0)".
+    let name = source_bytes
+        .get(loc.offset..loc.end())
+        .and_then(|slice| std::str::from_utf8(slice).ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!(".{}()", kind));
 
     let item = CallHierarchyItem {
         name,

--- a/src/goto.rs
+++ b/src/goto.rs
@@ -22,6 +22,11 @@ pub struct NodeInfo {
     pub node_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub member_location: Option<String>,
+    /// The `memberName` field from `MemberAccess` AST nodes.
+    /// Used to detect low-level calls (`.call`, `.staticcall`, `.delegatecall`)
+    /// which have `referencedDeclaration: null` in the AST.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub member_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub absolute_path: Option<String>,
     /// The AST `scope` field — the node ID of the containing declaration
@@ -176,6 +181,13 @@ pub struct CachedBuild {
     /// Offset is non-zero only for packed variables (e.g. two `bool`s
     /// sharing the same slot).
     pub storage_layout: HashMap<NodeId, StorageSlotInfo>,
+    /// Low-level external calls from Yul inline assembly.
+    ///
+    /// Contains `call`, `staticcall`, `delegatecall` Yul opcodes which
+    /// have no `id` field and are not in the `nodes` index.
+    /// Solidity-level `MemberAccess` low-level calls are in `nodes` and
+    /// detected at query time via `NodeInfo.member_name`.
+    pub low_level_calls: Vec<LowLevelCall>,
 }
 
 impl CachedBuild {
@@ -191,12 +203,12 @@ impl CachedBuild {
     /// [`PathInterner`].  This ensures all `CachedBuild` instances share the
     /// same file-ID space regardless of which solc invocation produced them.
     pub fn new(ast: Value, build_version: i32, interner: Option<&mut PathInterner>) -> Self {
-        let (mut nodes, path_to_abs, mut external_refs) = if let Some(sources) = ast.get("sources")
-        {
-            cache_ids(sources)
-        } else {
-            (HashMap::new(), HashMap::new(), HashMap::new())
-        };
+        let (mut nodes, path_to_abs, mut external_refs, mut low_level_calls) =
+            if let Some(sources) = ast.get("sources") {
+                cache_ids(sources)
+            } else {
+                (HashMap::new(), HashMap::new(), HashMap::new(), Vec::new())
+            };
 
         // Parse solc's source_id_to_path from the AST output.
         let solc_id_to_path: HashMap<SolcFileId, String> = ast
@@ -308,6 +320,14 @@ impl CachedBuild {
         // Build storage layout index from contracts[path][name].storageLayout.storage[].
         let storage_layout = build_storage_layout(&ast);
 
+        // Canonicalize Yul low-level call src strings if interner is active.
+        if let Some(ref remap) = canonical_remap {
+            for llc in &mut low_level_calls {
+                llc.src = SrcLocation::new(remap_src_canonical(llc.src.as_str(), remap));
+                llc.name_src = SrcLocation::new(remap_src_canonical(llc.name_src.as_str(), remap));
+            }
+        }
+
         // The raw AST JSON is fully consumed — all data has been extracted
         // into the pre-built indexes above. `ast` is dropped here.
 
@@ -325,6 +345,7 @@ impl CachedBuild {
             qualifier_refs,
             base_function_implementation,
             storage_layout,
+            low_level_calls,
         }
     }
 
@@ -435,6 +456,7 @@ impl CachedBuild {
             qualifier_refs,
             base_function_implementation,
             storage_layout: HashMap::new(),
+            low_level_calls: Vec::new(),
         }
     }
 }
@@ -566,11 +588,44 @@ fn build_base_function_implementation(
     index
 }
 
-/// Return type of [`cache_ids`]: `(nodes, path_to_abs, external_refs)`.
+/// A low-level call detected in the AST that has no `referencedDeclaration`.
+///
+/// Covers Yul opcodes (`call`, `staticcall`, `delegatecall`) from inline
+/// assembly. These `YulFunctionCall` nodes have NO `id` field, so they
+/// are NOT in the `nodes` index — they are collected here instead.
+///
+/// Solidity-level `MemberAccess` low-level calls (e.g. `addr.call(...)`)
+/// DO have `id` fields and ARE in `nodes`. They are detected at query
+/// time via `NodeInfo.member_name` and are NOT duplicated here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LowLevelCall {
+    /// `"call"`, `"staticcall"`, or `"delegatecall"`.
+    pub kind: String,
+    /// The `src` string of the `YulFunctionCall` node (`"offset:length:fileId"`).
+    /// Covers the entire call expression including arguments.
+    pub src: SrcLocation,
+    /// The `src` of the `functionName` identifier (e.g. just `call`).
+    /// Used for `selection_range` so the cursor targets the opcode name.
+    pub name_src: SrcLocation,
+    /// Absolute path of the file containing this call.
+    pub abs_path: AbsPath,
+}
+
+/// The set of low-level call member names on `address` that have no
+/// `referencedDeclaration` in solc's AST.
+pub const LOW_LEVEL_CALL_NAMES: &[&str] = &["call", "staticcall", "delegatecall"];
+
+/// The set of Yul opcodes that perform external calls.
+/// Only these are flagged from `YulFunctionCall`; other Yul builtins
+/// (mstore, sload, add, …) are not call edges.
+pub const YUL_CALL_OPCODES: &[&str] = &["call", "staticcall", "delegatecall"];
+
+/// Return type of [`cache_ids`]: `(nodes, path_to_abs, external_refs, low_level_calls)`.
 type CachedIds = (
     HashMap<AbsPath, HashMap<NodeId, NodeInfo>>,
     HashMap<RelPath, AbsPath>,
     ExternalRefs,
+    Vec<LowLevelCall>,
 );
 
 /// Rewrite the file-ID component of a `"offset:length:fileId"` string using
@@ -617,6 +672,7 @@ pub fn cache_ids(sources: &Value) -> CachedIds {
         HashMap::with_capacity(source_count);
     let mut path_to_abs: HashMap<RelPath, AbsPath> = HashMap::with_capacity(source_count);
     let mut external_refs: ExternalRefs = HashMap::with_capacity(source_count * 10);
+    let mut low_level_calls: Vec<LowLevelCall> = Vec::new();
 
     if let Some(sources_obj) = sources.as_object() {
         for (path, source_data) in sources_obj {
@@ -658,6 +714,7 @@ pub fn cache_ids(sources: &Value) -> CachedIds {
                                 .and_then(|v| v.as_str())
                                 .map(|s| s.to_string()),
                             member_location: None,
+                            member_name: None,
                             absolute_path: ast
                                 .get("absolutePath")
                                 .and_then(|v| v.as_str())
@@ -735,6 +792,10 @@ pub fn cache_ids(sources: &Value) -> CachedIds {
                                 .get("memberLocation")
                                 .and_then(|v| v.as_str())
                                 .map(|s| s.to_string()),
+                            member_name: tree
+                                .get("memberName")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string()),
                             absolute_path: tree
                                 .get("absolutePath")
                                 .and_then(|v| v.as_str())
@@ -768,6 +829,26 @@ pub fn cache_ids(sources: &Value) -> CachedIds {
                         }
                     }
 
+                    // Detect Yul call opcodes (call, staticcall, delegatecall).
+                    // YulFunctionCall nodes have no `id` field so they aren't
+                    // in the `nodes` index.  We check `functionName.name` and
+                    // only collect actual external-call opcodes, not
+                    // arithmetic/memory builtins like mstore, sload, add, etc.
+                    if tree.get("nodeType").and_then(|v| v.as_str()) == Some("YulFunctionCall")
+                        && let Some(fn_obj) = tree.get("functionName")
+                        && let Some(fn_name) = fn_obj.get("name").and_then(|v| v.as_str())
+                        && YUL_CALL_OPCODES.contains(&fn_name)
+                        && let Some(src) = tree.get("src").and_then(|v| v.as_str())
+                    {
+                        let fn_src = fn_obj.get("src").and_then(|v| v.as_str()).unwrap_or(src);
+                        low_level_calls.push(LowLevelCall {
+                            kind: fn_name.to_string(),
+                            src: SrcLocation::new(src),
+                            name_src: SrcLocation::new(fn_src),
+                            abs_path: abs_path.clone(),
+                        });
+                    }
+
                     for key in CHILD_KEYS {
                         push_if_node_or_array(tree, key, &mut stack);
                     }
@@ -776,7 +857,7 @@ pub fn cache_ids(sources: &Value) -> CachedIds {
         }
     }
 
-    (nodes, path_to_abs, external_refs)
+    (nodes, path_to_abs, external_refs, low_level_calls)
 }
 
 pub fn pos_to_bytes(source_bytes: &[u8], position: Position) -> usize {
@@ -2729,6 +2810,7 @@ contract B { uint256 public x; }
             referenced_declaration: None,
             node_type: Some("Identifier".to_string()),
             member_location: None,
+            member_name: None,
             absolute_path: None,
             scope: None,
             base_functions: vec![],
@@ -2739,6 +2821,7 @@ contract B { uint256 public x; }
         assert!(!serialized.contains("name_locations"));
         assert!(!serialized.contains("referenced_declaration"));
         assert!(!serialized.contains("member_location"));
+        assert!(!serialized.contains("member_name"));
         assert!(!serialized.contains("absolute_path"));
         assert!(!serialized.contains("scope"));
         assert!(!serialized.contains("base_functions"));
@@ -2764,6 +2847,7 @@ contract B { uint256 public x; }
             referenced_declaration: Some(NodeId(42)),
             node_type: Some("FunctionDefinition".to_string()),
             member_location: Some("220:6:7".to_string()),
+            member_name: Some("transfer".to_string()),
             absolute_path: Some("/src/Foo.sol".to_string()),
             scope: Some(NodeId(10)),
             base_functions: vec![NodeId(100), NodeId(200)],
@@ -2774,6 +2858,7 @@ contract B { uint256 public x; }
         assert!(serialized.contains("name_locations"));
         assert!(serialized.contains("referenced_declaration"));
         assert!(serialized.contains("member_location"));
+        assert!(serialized.contains("member_name"));
         assert!(serialized.contains("absolute_path"));
         assert!(serialized.contains("scope"));
         assert!(serialized.contains("base_functions"));

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -7090,6 +7090,16 @@ impl LanguageServer for ForgeLsp {
                     );
                     resolved_outgoing.push((callee_item, pos, call_range));
                 }
+
+                // Low-level calls (.call/.staticcall/.delegatecall + Yul opcodes).
+                let ll_calls = crate::call_hierarchy::outgoing_low_level_calls(build, cid);
+                for (ll_item, call_range) in ll_calls {
+                    let pos = (
+                        ll_item.selection_range.start.line,
+                        ll_item.selection_range.start.character,
+                    );
+                    resolved_outgoing.push((ll_item, pos, call_range));
+                }
             }
         }
 

--- a/tests/yul_external_references.rs
+++ b/tests/yul_external_references.rs
@@ -8,6 +8,7 @@ type CachedIds = (
     HashMap<AbsPath, HashMap<NodeId, goto::NodeInfo>>,
     HashMap<RelPath, AbsPath>,
     goto::ExternalRefs,
+    Vec<goto::LowLevelCall>,
 );
 
 /// Load poolmanager.json, normalize from solc shape, and run cache_ids.
@@ -21,7 +22,7 @@ fn load_ast() -> CachedIds {
 
 #[test]
 fn test_cache_ids_returns_external_refs() {
-    let (_nodes, _path_to_abs, external_refs) = load_ast();
+    let (_nodes, _path_to_abs, external_refs, _low_level_calls) = load_ast();
 
     // There should be external references (435 total across all InlineAssembly nodes)
     assert!(
@@ -32,7 +33,7 @@ fn test_cache_ids_returns_external_refs() {
 
 #[test]
 fn test_external_refs_for_get_sqrt_price_target() {
-    let (_nodes, _path_to_abs, external_refs) = load_ast();
+    let (_nodes, _path_to_abs, external_refs, _low_level_calls) = load_ast();
 
     // InlineAssembly node 8137 in getSqrtPriceTarget has 11 externalReferences:
     //   declaration 8128 (zeroForOne):         1 use  at src "2068:10:33"
@@ -62,7 +63,7 @@ fn test_external_refs_for_get_sqrt_price_target() {
 
 #[test]
 fn test_external_refs_exact_count_for_each_parameter() {
-    let (_nodes, _path_to_abs, external_refs) = load_ast();
+    let (_nodes, _path_to_abs, external_refs, _low_level_calls) = load_ast();
 
     // Count refs per declaration for the getSqrtPriceTarget parameters
     let count_for =
@@ -101,7 +102,7 @@ fn test_external_refs_exact_count_for_each_parameter() {
 
 #[test]
 fn test_solidity_nodes_unchanged() {
-    let (nodes, _path_to_abs, _external_refs) = load_ast();
+    let (nodes, _path_to_abs, _external_refs, _low_level_calls) = load_ast();
 
     // The u64-keyed HashMap should still contain Solidity nodes with their ids
     // Check that key Solidity declaration nodes exist
@@ -161,7 +162,7 @@ fn test_solidity_nodes_unchanged() {
 
 #[test]
 fn test_no_yul_src_keys_in_u64_map() {
-    let (_nodes, _path_to_abs, external_refs) = load_ast();
+    let (_nodes, _path_to_abs, external_refs, _low_level_calls) = load_ast();
 
     // Verify that none of the Yul src strings appear as node ids in the u64 map.
     // This confirms Yul data is kept separate.
@@ -200,7 +201,7 @@ fn test_goto_bytes_resolves_yul_identifier() {
         })
         .collect();
 
-    let (nodes, path_to_abs, external_refs) = goto::cache_ids(sources);
+    let (nodes, path_to_abs, external_refs, _low_level_calls) = goto::cache_ids(sources);
 
     // Byte offset 1802 is the start of sqrtPriceNextX96 Yul reference (src "1802:16:33")
     // It should resolve to the declaration of sqrtPriceNextX96 (id 8130)
@@ -283,7 +284,7 @@ fn setup_goto() -> SetupGotoResult {
             )
         })
         .collect();
-    let (nodes, path_to_abs, external_refs) = goto::cache_ids(sources);
+    let (nodes, path_to_abs, external_refs, _low_level_calls) = goto::cache_ids(sources);
     SetupGotoResult(nodes, path_to_abs, id_to_path, external_refs)
 }
 


### PR DESCRIPTION
## Summary

Closes #211

- `callHierarchy/outgoingCalls` now surfaces low-level `.call()`, `.staticcall()`, and `.delegatecall()` as synthetic call edges
- Covers both Solidity `MemberAccess` nodes (no `referencedDeclaration`) and Yul call opcodes (no AST `id`, scoped to actual call opcodes via `functionName.name` — not `mstore`/`sload`/etc.)
- Selection ranges point at the `.call` / opcode identifier site; names show actual source text (e.g. `user.call`, `delegatecall(0, 0, 0, 0, 0, 0)`)

## Changes

- **`src/goto.rs`** — `NodeInfo.member_name` field (from `memberName`), `LowLevelCall` struct with `name_src` for precise selection, `CachedBuild.low_level_calls`, extraction in `cache_ids()` via `functionName.name`
- **`src/call_hierarchy.rs`** — `outgoing_low_level_calls()` with two passes (Solidity MemberAccess + Yul opcodes), `low_level_call_item_from_src()` builder
- **`src/lsp.rs`** — handler calls `outgoing_low_level_calls()` alongside `outgoing_calls()`
- **`tests/yul_external_references.rs`** — updated `CachedIds` tuple for new return value
- **Docs** — FEATURES.md, CHANGELOG.md, and their docs/ mirrors