### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -7,6 +7,9 @@ on:
       - "src/**"
       - "tests/**"
 
+permissions:
+  contents: read
+
 jobs:
   release-preflight:
     name: Release Preflight


### PR DESCRIPTION
Potential fix for [https://github.com/asyncswap/solidity-language-server/security/code-scanning/2](https://github.com/asyncswap/solidity-language-server/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: set workflow-level permissions right after the `on` section (or after `name`) with:

- `contents: read`

This applies to all jobs in this workflow unless overridden, is minimal, and matches what this pipeline needs (checkout/build/test only). No imports, methods, or dependencies are required since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
