### PR TITLE
fix: references missed test-file usages on cold start

### DIFF
--- a/benchmarks/aave-ref.yaml
+++ b/benchmarks/aave-ref.yaml
@@ -1,0 +1,41 @@
+project: /Users/meek/developer/aave/aave-v4
+file: src/hub/interfaces/IHubBase.sol
+line: 22
+col: 8
+output: benchmarks/aave
+report: README.md
+
+iterations: 1
+warmup: 0
+index_timeout: 300
+timeout: 60
+
+servers:
+  - mmsaki@latest
+
+initializeSettings:
+  projectIndex:
+    fullProjectScan: true
+
+benchmarks:
+  - textDocument/references
+
+methods:
+  textDocument/references:
+    waitForProgressToken: "solidity/projectIndexFull"
+    # Symmetry batch — every cursor position points at the same `Add` symbol,
+    # so the LSP must return the same reference set from each. ground truth
+    # (grep): 16 refs total — 1 def, 1 emit in src, 14 in tests.
+    batch:
+      - file: src/hub/interfaces/IHubBase.sol
+        line: 22
+        col: 8        # the def: `event Add(...)`
+      - file: tests/contracts/hub/misc/Hub.Skim.t.sol
+        line: 55
+        col: 18       # `emit IHubBase.Add(...)`
+      - file: tests/contracts/hub/add-remove/Hub.Add.t.sol
+        line: 285
+        col: 18       # `emit IHubBase.Add(...)`
+      - file: tests/contracts/spoke/accrual/Spoke.AccrueLiquidityFee.t.sol
+        line: 266
+        col: 36       # `IHubBase.Add.selector`

--- a/benchmarks/inspect_results.py
+++ b/benchmarks/inspect_results.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Inspect a lsp-bench results.json by printing each Location with the
+resolved symbol text and its source line.
+
+Usage:
+  python3 inspect_results.py <path/to/results.json> [benchmark_index] [server_index]
+
+Defaults: benchmark 0, server 0.
+
+Exit status:
+  0 always (printer, not a verifier).
+"""
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    results_path = Path(sys.argv[1])
+    bench_idx = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+    server_idx = int(sys.argv[3]) if len(sys.argv) > 3 else 0
+
+    with results_path.open() as f:
+        data = json.load(f)
+
+    bench = data["benchmarks"][bench_idx]
+    server = bench["servers"][server_idx]
+    method = bench.get("name", "?")
+    server_name = server.get("server", "?")
+    response = server.get("response")
+
+    print(f"results: {results_path}")
+    print(f"benchmark[{bench_idx}]: {method}")
+    print(f"server[{server_idx}]:    {server_name}")
+    print(f"input:    {bench.get('input', '')[:200]}{'...' if len(bench.get('input', '')) > 200 else ''}")
+    print()
+
+    if response is None:
+        print("response: null")
+        return 0
+    if not isinstance(response, list):
+        print(f"response (type={type(response).__name__}): {json.dumps(response, indent=2)[:500]}")
+        return 0
+
+    print(f"total locations: {len(response)}")
+    print()
+
+    by_file: dict[str, list[dict]] = defaultdict(list)
+    for loc in response:
+        uri = loc.get("uri", "")
+        path = uri.replace("file://", "")
+        by_file[path].append(loc.get("range", {}))
+
+    # Find common prefix to shorten paths in output
+    paths = list(by_file.keys())
+    common = ""
+    if paths:
+        common = paths[0]
+        for p in paths[1:]:
+            i = 0
+            while i < len(common) and i < len(p) and common[i] == p[i]:
+                i += 1
+            common = common[:i]
+        # Trim back to a directory boundary
+        common = common.rsplit("/", 1)[0] + "/" if "/" in common else ""
+
+    for path in sorted(by_file):
+        rel = path[len(common):] if common and path.startswith(common) else path
+        ranges = sorted(
+            by_file[path],
+            key=lambda r: (r.get("start", {}).get("line", 0), r.get("start", {}).get("character", 0)),
+        )
+        try:
+            lines = Path(path).read_text().splitlines()
+        except OSError:
+            lines = []
+
+        print(f"=== {rel}  ({len(ranges)} refs) ===")
+        for r in ranges:
+            start = r.get("start", {})
+            end = r.get("end", {})
+            ln = start.get("line", 0)        # 0-indexed
+            sc = start.get("character", 0)
+            ec = end.get("character", 0)
+            line_text = lines[ln] if 0 <= ln < len(lines) else "<out-of-range>"
+            symbol = line_text[sc:ec] if 0 <= ln < len(lines) else ""
+            print(f"  {ln + 1:>5}:{sc + 1:<3}-{ec + 1:<3}  [{symbol}]  {line_text.strip()}")
+        print()
+
+    if common:
+        print(f"common prefix stripped: {common}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -4703,6 +4703,45 @@ impl LanguageServer for ForgeLsp {
                 );
                 locations.extend(sub_locations);
             }
+
+            // Per-file builds for files the user has opened. Each per-file
+            // build is the AST of that file's compile unit (the file plus
+            // its transitive imports), with its own solc id space. The
+            // project build may not yet cover those files (phase 2 still
+            // running, partial cache, compile failure for some files), but
+            // their per-file builds will contain refs that match the target
+            // when re-resolved by `byte_to_id` against `def_abs_path` /
+            // `def_byte_offset`. Without this iteration, references queried
+            // from a different file (e.g. `IHubBase.sol` defining `event Add`)
+            // would not see refs in test files that are present only in
+            // their own per-file builds.
+            //
+            // The current file's build was already searched as `file_build`,
+            // and `project_build` was searched above — exclude both to keep
+            // the workload minimal; `dedup_locations` handles overlaps.
+            let project_root_key = self.project_cache_key().await;
+            let other_builds: Vec<Arc<goto::CachedBuild>> = {
+                let cache = self.ast_cache.read().await;
+                cache
+                    .iter()
+                    .filter(|(key, _)| {
+                        key.as_str() != uri.to_string()
+                            && project_root_key.as_deref() != Some(key.as_str())
+                    })
+                    .map(|(_, v)| v.clone())
+                    .collect()
+            };
+            for other in &other_builds {
+                let extra = references::goto_references_for_target(
+                    other,
+                    &def_abs_path,
+                    def_byte_offset,
+                    None,
+                    params.context.include_declaration,
+                    Some(&current_abs),
+                );
+                locations.extend(extra);
+            }
         }
 
         // Deduplicate across all caches — removes exact duplicates and

--- a/src/project_cache.rs
+++ b/src/project_cache.rs
@@ -817,9 +817,26 @@ pub fn load_reference_cache_with_report(
             }
         }
 
-        // Complete = every saved file was reused with a matching hash.
-        let complete =
-            file_count_reused == file_count_hashed && current_hashes == persisted.file_hashes;
+        // Complete = every saved file was reused with a matching hash AND
+        // the saved set covers every project file (src/test/script). The
+        // second clause is what catches a phase-1-only cache: when a previous
+        // run saved only the src closure, every saved file still matches on
+        // disk, but project test/script files were never added to
+        // `file_hashes` — so without this coverage check we'd return
+        // `complete=true` and the eager indexer would skip phase 2 forever.
+        let project_covered = {
+            let project_files = crate::solc::discover_source_files(config);
+            let saved: std::collections::HashSet<&String> = persisted.file_hashes.keys().collect();
+            project_files.iter().all(|abs| {
+                pathdiff::diff_paths(abs, &config.root)
+                    .and_then(|rel| rel.to_str().map(|s| s.to_string()))
+                    .map(|rel| saved.contains(&rel))
+                    .unwrap_or(false)
+            })
+        };
+        let complete = file_count_reused == file_count_hashed
+            && current_hashes == persisted.file_hashes
+            && project_covered;
 
         return CacheLoadReport {
             build: Some(CachedBuild::from_reference_index(


### PR DESCRIPTION
Closes #218.

## Summary

Two related bugs caused `textDocument/references` to return a subset of refs that varied by which file the cursor was on:

1. **`project_cache.rs` `complete` flag was a tautology** — only verified the cache's own saved files still matched on disk, never that the saved set covered the project. A phase-1-only cache (src/ only) reported `complete=true` on next load, and the eager indexer skipped phase 2 forever.
2. **`references()` enumeration ignored per-file builds** — searched `file_build` + `project_build` + `sub_caches`, never the other per-file builds in `ast_cache` (even though `rename()` already does that exact iteration at `lsp.rs:4823-4830`). With `project_build` incomplete, refs in opened files' per-file builds were silently dropped.

## Fix

- `project_cache.rs`: extra `project_covered` clause in `load_reference_cache_with_report` walks `discover_source_files(config)` and asserts every project file has an entry in `persisted.file_hashes`. Any missing project file → `complete=false` → caller falls through to phase 1 + phase 2.
- `lsp.rs::references`: iterate `ast_cache` for builds whose key is neither the current URI nor the project-root key; call `goto_references_for_target` on each (`byte_to_id` re-resolves the target in each build's id space). `Some(&current_abs)` excludes the current file; `dedup_locations` handles overlap with `project_build`.

## Test plan

- [x] `lsp-bench` `batch` symmetry check across 4 cursor positions on aave-v4's `IHubBase.Add` symbol
- [x] Cold-cache run from a wiped `.solidity-language-server/` returns 16 refs from every cursor (matches grep ground truth)
- [x] Without the fix, the same probe returns 2/8/12/16 depending on which file the cursor was on (asymmetric)

Reproducer: `benchmarks/aave-ref.yaml` (uses the new `batch` feature added to lsp-bench).

🤖 Generated with [Claude Code](https://claude.com/claude-code)