### PR TITLE
update bench YAML keys: renameSteps/createSteps/deleteSteps → renameFiles/createFiles/deleteFiles

### DIFF
--- a/benchmarks/ci-file-ops-verify.yaml
+++ b/benchmarks/ci-file-ops-verify.yaml
@@ -24,15 +24,15 @@ benchmarks:
 
 methods:
   workspace/willCreateFiles:
-    createSteps:
+    createFiles:
       - file: CIFileOpsCreate.sol
 
   workspace/willDeleteFiles:
-    deleteSteps:
+    deleteFiles:
       - file: B.sol
 
   workspace/willRenameFiles:
-    renameSteps:
+    renameFiles:
       - file: A.sol
         newName: AA.sol
       - file: AA.sol

--- a/benchmarks/example-rename-sequence.yaml
+++ b/benchmarks/example-rename-sequence.yaml
@@ -29,7 +29,7 @@ benchmarks:
 
 methods:
   workspace/willRenameFiles:
-    renameSteps:
+    renameFiles:
       # Step 1: A.sol → AA.sol
       - file: A.sol
         newName: AA.sol

--- a/benchmarks/extsload-rename-sequence.yaml
+++ b/benchmarks/extsload-rename-sequence.yaml
@@ -21,7 +21,7 @@ benchmarks:
 
 methods:
   workspace/willRenameFiles:
-    renameSteps:
+    renameFiles:
       # Step 1: Extsload.sol → Extsloads.sol (add s)
       - file: src/Extsload.sol
         newName: Extsloads.sol

--- a/benchmarks/pool-rename-sequence.yaml
+++ b/benchmarks/pool-rename-sequence.yaml
@@ -26,7 +26,7 @@ benchmarks:
 
 methods:
   workspace/willRenameFiles:
-    renameSteps:
+    renameFiles:
       # Step 1: Pool.sol → Pools.sol
       - file: src/libraries/Pool.sol
         newName: Pools.sol

--- a/benchmarks/pool.yaml
+++ b/benchmarks/pool.yaml
@@ -69,7 +69,7 @@ methods:
     # Inside TickMath.getTickAtSqrtPrice(sqrtPriceX96)
 
   workspace/willRenameFiles:
-    renameSteps:
+    renameFiles:
       - file: src/libraries/Pool.sol
         newName: Pools.sol
       - file: src/libraries/Pools.sol
@@ -77,11 +77,11 @@ methods:
     # Rename Pool.sol -> Pools.sol, then rename back to original path.
 
   workspace/willCreateFiles:
-    createSteps:
+    createFiles:
       - file: src/libraries/PoolBenchCreate.s.sol
     # Create lifecycle benchmark in v4-core/src/libraries (script template scaffold).
 
   workspace/willDeleteFiles:
-    deleteSteps:
+    deleteFiles:
       - file: src/libraries/Pool.sol
     # Delete lifecycle benchmark for Pool.sol (restored after run).

--- a/benchmarks/poolmanager-t-file-ops.yaml
+++ b/benchmarks/poolmanager-t-file-ops.yaml
@@ -35,13 +35,13 @@ benchmarks:
 
 methods:
   workspace/willCreateFiles:
-    createSteps:
+    createFiles:
       - file: test/PoolManagerBenchCreate.sol
     # Full create lifecycle:
     # willCreateFiles -> apply edits -> create on disk -> didCreateFiles
 
   workspace/willRenameFiles:
-    renameSteps:
+    renameFiles:
       - file: src/libraries/Pool.sol
         newName: Pools.sol
       - file: src/libraries/Pools.sol
@@ -50,7 +50,7 @@ methods:
     # willRenameFiles -> apply edits -> rename on disk -> didRenameFiles
 
   workspace/willDeleteFiles:
-    deleteSteps:
+    deleteFiles:
       - file: src/libraries/Pool.sol
     # Full delete lifecycle:
     # willDeleteFiles -> apply edits -> delete on disk -> didDeleteFiles

--- a/benchmarks/poolmanager-t.yaml
+++ b/benchmarks/poolmanager-t.yaml
@@ -69,7 +69,7 @@ methods:
     # Inside bound(sqrtPriceX96, TickMath.MIN_SQRT_PRICE, ...)
 
   workspace/willRenameFiles:
-    renameSteps:
+    renameFiles:
       - file: src/libraries/Pool.sol
         newName: Pools.sol
       - file: src/libraries/Pools.sol
@@ -77,11 +77,11 @@ methods:
     # Rename Pool.sol -> Pools.sol, then rename back to original path.
 
   workspace/willCreateFiles:
-    createSteps:
+    createFiles:
       - file: test/PoolManagerBenchCreate.sol
     # Create lifecycle benchmark; helper restores original state after run.
 
   workspace/willDeleteFiles:
-    deleteSteps:
+    deleteFiles:
       - file: src/libraries/Pool.sol
     # Delete lifecycle benchmark; helper restores original state after run.

--- a/benchmarks/shop.yaml
+++ b/benchmarks/shop.yaml
@@ -140,7 +140,7 @@ methods:
     # Inside addTax(TAX, TAX_BASE) — first argument position
 
   workspace/willRenameFiles:
-    renameSteps:
+    renameFiles:
       - file: A.sol
         newName: AA.sol
       - file: AA.sol
@@ -148,11 +148,11 @@ methods:
     # Rename A.sol -> AA.sol, then back. Should update Shop.sol import path.
 
   workspace/willCreateFiles:
-    createSteps:
+    createFiles:
       - file: ShopBenchCreate.s.sol
     # Create lifecycle benchmark in example project (script template scaffold).
 
   workspace/willDeleteFiles:
-    deleteSteps:
+    deleteFiles:
       - file: A.sol
     # Delete lifecycle benchmark for imported file A.sol.


### PR DESCRIPTION
## Summary

Tracks the breaking rename in lsp-bench (asyncswap/lsp-bench#21). The YAML keys for `workspace/willRenameFiles` / `willCreateFiles` / `willDeleteFiles` lifecycle methods now match their LSP method names:

| Before | After |
|---|---|
| `renameSteps:` | `renameFiles:` |
| `createSteps:` | `createFiles:` |
| `deleteSteps:` | `deleteFiles:` |

Mechanical update across 8 YAML configs:

```sh
sed -i '' 's/renameSteps/renameFiles/g; s/createSteps/createFiles/g; s/deleteSteps/deleteFiles/g' benchmarks/*.yaml
```

## Files

- `benchmarks/ci-file-ops-verify.yaml`
- `benchmarks/example-rename-sequence.yaml`
- `benchmarks/extsload-rename-sequence.yaml`
- `benchmarks/pool-rename-sequence.yaml`
- `benchmarks/pool.yaml`
- `benchmarks/poolmanager-t-file-ops.yaml`
- `benchmarks/poolmanager-t.yaml`
- `benchmarks/shop.yaml`

## Test plan

- [x] Rebuild lsp-bench from `asyncswap/lsp-bench#21` and install
- [x] Smoke test: `lsp-bench -c benchmarks/example-rename-sequence.yaml` — passes (4 files with edits per round-trip step)

⚠️ Requires the lsp-bench PR to land first; older `lsp-bench` builds will reject these configs with an unknown-key error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)