### PR TITLE
fix: phase-2 log no longer reports stale phase-1 count as freshly compiled

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -2967,6 +2967,13 @@ impl LanguageServer for ForgeLsp {
                                 0,
                                 Some(&mut *phase2_path_interner.write().await),
                             );
+                            // Capture how many sources phase 2's solc actually
+                            // compiled this round, BEFORE merging in phase-1
+                            // data — otherwise the log conflates "files
+                            // freshly compiled" with "files already in cache",
+                            // making a silent phase-2 failure (0 ASTs back)
+                            // look like a successful run.
+                            let phase2_compiled = new_build.nodes.len();
                             // Merge any data from the phase-1 build that
                             // might not be in the full closure (shouldn't
                             // happen, but defensive).
@@ -2981,15 +2988,22 @@ impl LanguageServer for ForgeLsp {
                                 .write()
                                 .await
                                 .insert(phase2_cache_key.clone().into(), cached_build);
-                            phase2_client
-                                .log_message(
-                                    MessageType::INFO,
-                                    format!(
-                                         "project index: phase 2 complete — {} source files indexed in {:.1}s",
-                                        source_count,
-                                        phase2_start.elapsed().as_secs_f64(),
-                                    ),
+                            let phase2_message = if phase2_compiled == 0 {
+                                format!(
+                                    "project index: phase 2 produced no ASTs in {:.1}s — solc likely errored on the batch (cache retains {} merged sources from phase 1)",
+                                    phase2_start.elapsed().as_secs_f64(),
+                                    source_count,
                                 )
+                            } else {
+                                format!(
+                                    "project index: phase 2 complete — {} sources compiled this round, {} total in cache, in {:.1}s",
+                                    phase2_compiled,
+                                    source_count,
+                                    phase2_start.elapsed().as_secs_f64(),
+                                )
+                            };
+                            phase2_client
+                                .log_message(MessageType::INFO, phase2_message)
                                 .await;
 
                             // Pre-load lib sub-caches after full build.


### PR DESCRIPTION
## Summary

Phase-2 of the project index logs how many sources it compiled. Before this fix, the count was read **after** `merge_missing_from(prev)` ran — so when phase-2's solc returned zero ASTs (e.g. the batch errored mid-compile), the log still reported phase-1's full count as if everything was healthy:

```
project index: phase 2 complete — 181 source files indexed in 0.3s
```

The only signal something was wrong was the implausible 0.3s wall time. Anyone debugging cross-file misses would naturally assume phase 2 succeeded.

## Fix

Capture the freshly-compiled node count **before** the merge runs, then emit one of two messages depending on what came back from solc:

```
# healthy
project index: phase 2 complete — 477 sources compiled this round, 477 total in cache, in 14.8s

# silent failure
project index: phase 2 produced no ASTs in 0.3s — solc likely errored on the batch (cache retains 181 merged sources from phase 1)
```

Two numbers (`compiled this round` vs `total in cache`) make merge-vs-fresh attribution unambiguous; the empty-result branch surfaces the failure mode directly.

## Test plan

- [x] `cargo build --release` clean
- [x] Manual review of the conditional — both branches reachable: zero-ASTs path triggers when `new_build.nodes.is_empty()` after construction, healthy path otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)