### PR TITLE
fix: add context-aware SPDX and pragma completions

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1771,6 +1771,7 @@ fn prefix_at_byte(line: &str, col_byte: u32) -> &str {
 }
 
 fn source_unit_directive_completions(
+    line: &str,
     line_prefix: &str,
     position: Position,
 ) -> Option<Vec<CompletionItem>> {
@@ -1789,15 +1790,18 @@ fn source_unit_directive_completions(
         }
     }
 
-    if let Some(after_solidity) = trimmed.strip_prefix("pragma solidity") {
+    if let Some(after_solidity) = strip_directive_value(trimmed, "pragma solidity") {
         if after_solidity.contains(';') {
             return Some(vec![]);
         }
 
-        return Some(solidity_version_completions());
+        return Some(solidity_version_completions(
+            position,
+            directive_value_range(line, "pragma solidity"),
+        ));
     }
 
-    if let Some(after_abicoder) = trimmed.strip_prefix("pragma abicoder") {
+    if let Some(after_abicoder) = strip_directive_value(trimmed, "pragma abicoder") {
         if after_abicoder.contains(';') {
             return Some(vec![]);
         }
@@ -1823,6 +1827,15 @@ fn source_unit_directive_completions(
     }
 
     None
+}
+
+fn strip_directive_value<'a>(line: &'a str, directive: &str) -> Option<&'a str> {
+    let rest = line.strip_prefix(directive)?;
+    if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+        Some(rest)
+    } else {
+        None
+    }
 }
 
 fn is_spdx_directive_prefix(upper_comment_body: &str) -> bool {
@@ -1867,7 +1880,69 @@ fn spdx_license_identifier_completions() -> Vec<CompletionItem> {
     .collect()
 }
 
-fn solidity_version_completions() -> Vec<CompletionItem> {
+fn directive_value_range(line: &str, directive: &str) -> Range {
+    let mut byte = line
+        .find(directive)
+        .map(|idx| idx + directive.len())
+        .unwrap_or(line.len());
+
+    while byte < line.len() {
+        let ch = line[byte..]
+            .chars()
+            .next()
+            .expect("byte is within string bounds");
+        if !ch.is_whitespace() {
+            break;
+        }
+        byte += ch.len_utf8();
+    }
+
+    let end_byte = line[byte..]
+        .find(';')
+        .map(|idx| byte + idx)
+        .unwrap_or(line.len());
+
+    Range {
+        start: Position {
+            line: 0,
+            character: line[..byte].encode_utf16().count() as u32,
+        },
+        end: Position {
+            line: 0,
+            character: line[..end_byte].encode_utf16().count() as u32,
+        },
+    }
+}
+
+fn version_completion_item(
+    label: impl Into<String>,
+    detail: impl Into<String>,
+    position: Position,
+    range: Range,
+) -> CompletionItem {
+    let label = label.into();
+    CompletionItem {
+        label: label.clone(),
+        kind: Some(CompletionItemKind::CONSTANT),
+        detail: Some(detail.into()),
+        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+            range: Range {
+                start: Position {
+                    line: position.line,
+                    character: range.start.character,
+                },
+                end: Position {
+                    line: position.line,
+                    character: range.end.character,
+                },
+            },
+            new_text: label,
+        })),
+        ..Default::default()
+    }
+}
+
+fn solidity_version_completions(position: Position, range: Range) -> Vec<CompletionItem> {
     [
         ("^0.8.35", "Latest Solidity 0.8.x compatible range"),
         ("0.8.35", "Latest Solidity exact version"),
@@ -1875,7 +1950,7 @@ fn solidity_version_completions() -> Vec<CompletionItem> {
         (">=0.8.0 <0.9.0", "Solidity 0.8.x range"),
     ]
     .into_iter()
-    .map(|(version, detail)| completion_item(version, CompletionItemKind::CONSTANT, detail))
+    .map(|(version, detail)| version_completion_item(version, detail, position, range))
     .collect()
 }
 
@@ -2040,7 +2115,8 @@ pub fn handle_completion_with_tail_candidates(
         .unwrap_or(0);
     let col_byte = (abs_byte - line_start_byte) as u32;
 
-    if let Some(items) = source_unit_directive_completions(prefix_at_byte(line, col_byte), position)
+    if let Some(items) =
+        source_unit_directive_completions(line, prefix_at_byte(line, col_byte), position)
     {
         return Some(CompletionResponse::List(CompletionList {
             is_incomplete: false,

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -2,8 +2,8 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
 use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionList, CompletionResponse, Position, Range,
-    TextEdit,
+    CompletionItem, CompletionItemKind, CompletionList, CompletionResponse, CompletionTextEdit,
+    Position, Range, TextEdit,
 };
 
 use crate::goto::CHILD_KEYS;
@@ -1722,6 +1722,163 @@ pub fn get_general_completions(cache: &CompletionCache) -> Vec<CompletionItem> {
     items
 }
 
+fn completion_item(
+    label: impl Into<String>,
+    kind: CompletionItemKind,
+    detail: impl Into<String>,
+) -> CompletionItem {
+    CompletionItem {
+        label: label.into(),
+        kind: Some(kind),
+        detail: Some(detail.into()),
+        ..Default::default()
+    }
+}
+
+fn line_replacement_item(
+    label: impl Into<String>,
+    detail: impl Into<String>,
+    new_text: impl Into<String>,
+    position: Position,
+) -> CompletionItem {
+    let label = label.into();
+    let new_text = new_text.into();
+    CompletionItem {
+        filter_text: Some(format!("spdx {label} {new_text}")),
+        label,
+        kind: Some(CompletionItemKind::CONSTANT),
+        detail: Some(detail.into()),
+        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+            range: Range {
+                start: Position {
+                    line: position.line,
+                    character: 0,
+                },
+                end: position,
+            },
+            new_text,
+        })),
+        ..Default::default()
+    }
+}
+
+fn prefix_at_byte(line: &str, col_byte: u32) -> &str {
+    let mut end = (col_byte as usize).min(line.len());
+    while !line.is_char_boundary(end) {
+        end -= 1;
+    }
+    &line[..end]
+}
+
+fn source_unit_directive_completions(
+    line_prefix: &str,
+    position: Position,
+) -> Option<Vec<CompletionItem>> {
+    let trimmed = line_prefix.trim_start();
+
+    if let Some(after_slashes) = trimmed.strip_prefix("//") {
+        let body = after_slashes.trim_start();
+        let upper = body.to_ascii_uppercase();
+
+        if upper.starts_with("SPDX-LICENSE-IDENTIFIER:") {
+            return Some(spdx_license_identifier_completions());
+        }
+
+        if is_spdx_directive_prefix(&upper) {
+            return Some(spdx_directive_completions(position));
+        }
+    }
+
+    if let Some(after_solidity) = trimmed.strip_prefix("pragma solidity") {
+        if after_solidity.contains(';') {
+            return Some(vec![]);
+        }
+
+        return Some(solidity_version_completions());
+    }
+
+    if let Some(after_abicoder) = trimmed.strip_prefix("pragma abicoder") {
+        if after_abicoder.contains(';') {
+            return Some(vec![]);
+        }
+
+        return Some(vec![
+            completion_item("v2", CompletionItemKind::CONSTANT, "ABI coder v2"),
+            completion_item("v1", CompletionItemKind::CONSTANT, "ABI coder v1"),
+        ]);
+    }
+
+    if let Some(after_pragma) = trimmed.strip_prefix("pragma")
+        && !after_pragma.is_empty()
+        && after_pragma.trim().is_empty()
+    {
+        return Some(vec![
+            completion_item(
+                "solidity",
+                CompletionItemKind::KEYWORD,
+                "Compiler version pragma",
+            ),
+            completion_item("abicoder", CompletionItemKind::KEYWORD, "ABI coder pragma"),
+        ]);
+    }
+
+    None
+}
+
+fn is_spdx_directive_prefix(upper_comment_body: &str) -> bool {
+    let body = upper_comment_body.trim_start();
+    !body.is_empty() && ("SPDX".starts_with(body) || body.starts_with("SPDX"))
+}
+
+fn spdx_directive_completions(position: Position) -> Vec<CompletionItem> {
+    vec![
+        line_replacement_item(
+            "// SPDX-License-Identifier: MIT",
+            "SPDX license identifier",
+            "// SPDX-License-Identifier: MIT",
+            position,
+        ),
+        line_replacement_item(
+            "// SPDX-License-Identifier: UNLICENSED",
+            "SPDX license identifier",
+            "// SPDX-License-Identifier: UNLICENSED",
+            position,
+        ),
+        line_replacement_item(
+            "// SPDX-License-Identifier: Apache-2.0",
+            "SPDX license identifier",
+            "// SPDX-License-Identifier: Apache-2.0",
+            position,
+        ),
+    ]
+}
+
+fn spdx_license_identifier_completions() -> Vec<CompletionItem> {
+    [
+        "MIT",
+        "UNLICENSED",
+        "Apache-2.0",
+        "GPL-3.0-only",
+        "GPL-3.0-or-later",
+        "BSD-3-Clause",
+    ]
+    .into_iter()
+    .map(|license| completion_item(license, CompletionItemKind::CONSTANT, "SPDX license"))
+    .collect()
+}
+
+fn solidity_version_completions() -> Vec<CompletionItem> {
+    [
+        ("^0.8.35", "Latest Solidity 0.8.x compatible range"),
+        ("0.8.35", "Latest Solidity exact version"),
+        ("^0.8.0", "Solidity 0.8.x compatible range"),
+        (">=0.8.0 <0.9.0", "Solidity 0.8.x range"),
+    ]
+    .into_iter()
+    .map(|(version, detail)| completion_item(version, CompletionItemKind::CONSTANT, detail))
+    .collect()
+}
+
 /// Append auto-import candidates at the tail of completion results.
 ///
 /// This enforces lower priority ordering by:
@@ -1882,6 +2039,14 @@ pub fn handle_completion_with_tail_candidates(
         .map(|i| i + 1)
         .unwrap_or(0);
     let col_byte = (abs_byte - line_start_byte) as u32;
+
+    if let Some(items) = source_unit_directive_completions(prefix_at_byte(line, col_byte), position)
+    {
+        return Some(CompletionResponse::List(CompletionList {
+            is_incomplete: false,
+            items,
+        }));
+    }
 
     // Build scope context for scope-aware type resolution
     let scope_ctx = file_id.map(|fid| ScopeContext {

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -459,6 +459,69 @@ fn test_context_completion_pragma_solidity_versions() {
 }
 
 #[test]
+fn test_context_completion_pragma_directive_requires_token_boundary() {
+    let labels = response_labels(handle_completion(
+        None,
+        "pragma solidityx",
+        Position {
+            line: 0,
+            character: "pragma solidityx".len() as u32,
+        },
+        None,
+        None,
+    ));
+
+    assert!(!labels.contains(&"^0.8.35".to_string()));
+    assert!(!labels.contains(&"^0.8.0".to_string()));
+
+    let labels = response_labels(handle_completion(
+        None,
+        "pragma abicoderx",
+        Position {
+            line: 0,
+            character: "pragma abicoderx".len() as u32,
+        },
+        None,
+        None,
+    ));
+
+    assert!(!labels.contains(&"v2".to_string()));
+    assert!(!labels.contains(&"v1".to_string()));
+}
+
+#[test]
+fn test_context_completion_pragma_solidity_version_replaces_partial_token() {
+    let source = "pragma solidity 0.* ^0.8.35;";
+    let items = response_items(handle_completion(
+        None,
+        source,
+        Position {
+            line: 0,
+            character: "pragma solidity 0.*".len() as u32,
+        },
+        None,
+        None,
+    ));
+    let version = items
+        .iter()
+        .find(|item| item.label == "^0.8.35")
+        .expect("^0.8.35 completion");
+    let edit = match version.text_edit.as_ref().expect("version text edit") {
+        CompletionTextEdit::Edit(edit) => edit,
+        CompletionTextEdit::InsertAndReplace(_) => panic!("expected replacement edit"),
+    };
+
+    assert_eq!(edit.range.start.line, 0);
+    assert_eq!(edit.range.start.character, "pragma solidity ".len() as u32);
+    assert_eq!(edit.range.end.line, 0);
+    assert_eq!(
+        edit.range.end.character,
+        "pragma solidity 0.* ^0.8.35".len() as u32
+    );
+    assert_eq!(edit.new_text, "^0.8.35");
+}
+
+#[test]
 fn test_context_completion_finished_pragma_is_empty() {
     let source = "pragma solidity ^0.8.0;";
     let labels = response_labels(handle_completion(

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -2,11 +2,13 @@ use serde_json::Value;
 use solidity_language_server::completion::{
     AccessKind, DotSegment, build_completion_cache, extract_identifier_before_dot,
     extract_mapping_value_type, extract_node_id_from_type, get_dot_completions,
-    get_general_completions, parse_dot_chain,
+    get_general_completions, handle_completion, parse_dot_chain,
 };
 use solidity_language_server::types::{FileId, NodeId};
 use std::fs;
-use tower_lsp::lsp_types::CompletionItemKind;
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionResponse, CompletionTextEdit, Position,
+};
 
 fn load_ast() -> Value {
     let raw: Value =
@@ -19,6 +21,22 @@ fn load_cache() -> solidity_language_server::completion::CompletionCache {
     let sources = ast_data.get("sources").unwrap();
     let contracts = ast_data.get("contracts");
     build_completion_cache(sources, contracts, None)
+}
+
+fn response_labels(resp: Option<CompletionResponse>) -> Vec<String> {
+    match resp {
+        Some(CompletionResponse::List(list)) => list.items.into_iter().map(|i| i.label).collect(),
+        Some(CompletionResponse::Array(items)) => items.into_iter().map(|i| i.label).collect(),
+        None => vec![],
+    }
+}
+
+fn response_items(resp: Option<CompletionResponse>) -> Vec<CompletionItem> {
+    match resp {
+        Some(CompletionResponse::List(list)) => list.items,
+        Some(CompletionResponse::Array(items)) => items,
+        None => vec![],
+    }
 }
 
 // --- extract_node_id_from_type ---
@@ -329,6 +347,132 @@ fn test_general_completions_include_keywords() {
     );
     assert!(names.contains(&"if"), "Should have 'if' keyword");
     assert!(names.contains(&"mapping"), "Should have 'mapping' keyword");
+}
+
+#[test]
+fn test_context_completion_spdx_directive() {
+    let items = response_items(handle_completion(
+        None,
+        "// SPDX",
+        Position {
+            line: 0,
+            character: 7,
+        },
+        None,
+        None,
+    ));
+    let labels: Vec<&str> = items.iter().map(|item| item.label.as_str()).collect();
+    let mit = items
+        .iter()
+        .find(|item| item.label == "// SPDX-License-Identifier: MIT")
+        .expect("MIT SPDX completion");
+
+    assert!(labels.contains(&"// SPDX-License-Identifier: MIT"));
+    assert!(!labels.contains(&"pragma"));
+    assert_eq!(mit.kind, Some(CompletionItemKind::CONSTANT));
+    assert_ne!(mit.kind, Some(CompletionItemKind::TEXT));
+    assert_eq!(
+        mit.filter_text.as_deref(),
+        Some("spdx // SPDX-License-Identifier: MIT // SPDX-License-Identifier: MIT")
+    );
+}
+
+#[test]
+fn test_context_completion_spdx_directive_from_short_prefix() {
+    let labels = response_labels(handle_completion(
+        None,
+        "// SP",
+        Position {
+            line: 0,
+            character: 5,
+        },
+        None,
+        None,
+    ));
+
+    assert!(labels.contains(&"// SPDX-License-Identifier: MIT".to_string()));
+    assert!(!labels.contains(&"selfdestruct(address payable recipient)".to_string()));
+    assert!(!labels.contains(&"super".to_string()));
+}
+
+#[test]
+fn test_context_completion_spdx_directive_replaces_comment_prefix() {
+    let items = response_items(handle_completion(
+        None,
+        "// SP",
+        Position {
+            line: 0,
+            character: 5,
+        },
+        None,
+        None,
+    ));
+    let mit = items
+        .iter()
+        .find(|item| item.label == "// SPDX-License-Identifier: MIT")
+        .expect("MIT SPDX completion");
+    let edit = match mit.text_edit.as_ref().expect("SPDX text edit") {
+        CompletionTextEdit::Edit(edit) => edit,
+        CompletionTextEdit::InsertAndReplace(_) => panic!("expected line replacement edit"),
+    };
+
+    assert_eq!(edit.range.start.line, 0);
+    assert_eq!(edit.range.start.character, 0);
+    assert_eq!(edit.range.end.line, 0);
+    assert_eq!(edit.range.end.character, 5);
+    assert_eq!(edit.new_text, "// SPDX-License-Identifier: MIT");
+}
+
+#[test]
+fn test_context_completion_pragma_keyword() {
+    let labels = response_labels(handle_completion(
+        None,
+        "pragma ",
+        Position {
+            line: 0,
+            character: 7,
+        },
+        None,
+        None,
+    ));
+
+    assert_eq!(labels, vec!["solidity".to_string(), "abicoder".to_string()]);
+}
+
+#[test]
+fn test_context_completion_pragma_solidity_versions() {
+    let labels = response_labels(handle_completion(
+        None,
+        "pragma solidity ",
+        Position {
+            line: 0,
+            character: 16,
+        },
+        None,
+        None,
+    ));
+
+    assert!(labels.contains(&"^0.8.35".to_string()));
+    assert!(labels.contains(&"^0.8.0".to_string()));
+    assert!(!labels.contains(&"revert()".to_string()));
+    assert!(!labels.contains(&"msg".to_string()));
+}
+
+#[test]
+fn test_context_completion_finished_pragma_is_empty() {
+    let source = "pragma solidity ^0.8.0;";
+    let labels = response_labels(handle_completion(
+        None,
+        source,
+        Position {
+            line: 0,
+            character: source.len() as u32,
+        },
+        None,
+        None,
+    ));
+
+    assert!(labels.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Closes #223

## Problem

Completion inside source-unit directive contexts can fall through to normal/global Solidity completions. This makes early SPDX and pragma typing noisy, and SPDX insertion can duplicate the existing `//` prefix depending on the client.

## Fix

- Detect SPDX directive prefixes such as `// S`, `// SP`, `// SPD`, and `// SPDX`.
- Offer full SPDX license directive lines using a line replacement edit.
- Add pragma completions for `pragma `, `pragma solidity `, and `pragma abicoder ` contexts.
- Suppress unrelated generic/global completions in those directive contexts.

## Tests

- `rustfmt src/completion.rs tests/completion.rs`
- `cargo check`
- `cargo test --test completion -- --nocapture`
- `cargo test --lib -- --nocapture`
- `cargo test`
- `cargo build --release --bin solidity-language-server`
- `git diff --check`
