### PR TITLE
ci: publish to crates.io on release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,32 @@ jobs:
           name: solidity-language-server-${{ matrix.target }}
           path: solidity-language-server-${{ matrix.target }}.*
 
+  publish-crate:
+    name: Publish to crates.io
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
+      - name: Verify tag matches Cargo.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)" >&2
+            exit 1
+          fi
+
+      - name: Publish
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   release:
     name: Create Release
     needs: build


### PR DESCRIPTION
## Summary

Adds a `publish-crate` job to the release workflow so each `v*` tag automatically publishes the crate to crates.io alongside the binary release.

- Runs after the build matrix succeeds, so a broken build is never published
- Verifies the tag version matches the version in `Cargo.toml` (fails the job on mismatch instead of publishing a stale version)
- Publishes with `cargo publish --locked` using the committed `Cargo.lock`
- Actions pinned by SHA, matching the rest of the workflow

## Setup required

A crates.io API token (scope: `publish-update`) must be added as the `CARGO_REGISTRY_TOKEN` repository secret before the next release tag.